### PR TITLE
Start client event listener

### DIFF
--- a/elasti-gneiss-aws/src/main.rs
+++ b/elasti-gneiss-aws/src/main.rs
@@ -5,13 +5,12 @@
 
 use std::fs::File;
 use argh::FromArgs;
-use elasti_gneiss_core::{client_event_callback, ElastiError, ElastiResult, main_loop};
+use elasti_gneiss_core::{ElastiError, ElastiResult, main_loop};
 use gneiss_mqtt::client::Mqtt5Client;
 use gneiss_mqtt::config::*;
 use gneiss_mqtt_aws::{AwsClientBuilder, AwsCustomAuthOptions, WebsocketSigv4OptionsBuilder};
 use simplelog::{LevelFilter, WriteLogger};
 use std::path::PathBuf;
-use std::sync::Arc;
 use tokio::runtime::Handle;
 use url::Url;
 
@@ -165,15 +164,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         WriteLogger::init(LevelFilter::Debug, log_config, log_file_result.unwrap()).unwrap();
     }
 
-    let function = |event|{client_event_callback(event)} ;
-    let dyn_function = Arc::new(function);
-    let callback = ClientEventListener::Callback(dyn_function);
-
     let connect_options = ConnectOptionsBuilder::new().build();
 
     let config = Mqtt5ClientOptionsBuilder::new()
         .with_offline_queue_policy(OfflineQueuePolicy::PreserveAll)
-        .with_default_event_listener(callback)
         .with_reconnect_period_jitter(ExponentialBackoffJitterType::Uniform)
         .build();
 

--- a/elasti-gneiss-core/src/lib.rs
+++ b/elasti-gneiss-core/src/lib.rs
@@ -173,7 +173,10 @@ pub fn client_event_callback(event: Arc<ClientEvent>) {
 }
 
 fn handle_start(client: &Mqtt5Client, _: StartArgs) {
-    let _ = client.start();
+    let function = |event|{ client_event_callback(event) };
+    let listener_callback = Arc::new(function);
+
+    let _ = client.start(Some(listener_callback));
 }
 
 fn handle_stop(client: &Mqtt5Client, args: StopArgs) {

--- a/elasti-gneiss/src/main.rs
+++ b/elasti-gneiss/src/main.rs
@@ -5,12 +5,11 @@
 
 use std::fs::File;
 use argh::FromArgs;
-use elasti_gneiss_core::{client_event_callback, ElastiError, ElastiResult, main_loop};
+use elasti_gneiss_core::{ElastiError, ElastiResult, main_loop};
 use gneiss_mqtt::client::Mqtt5Client;
 use gneiss_mqtt::config::*;
 use simplelog::{LevelFilter, WriteLogger};
 use std::path::PathBuf;
-use std::sync::Arc;
 use tokio::runtime::Handle;
 use url::Url;
 use gneiss_mqtt::alias::OutboundAliasResolverFactory;
@@ -152,10 +151,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         WriteLogger::init(LevelFilter::Debug, log_config, log_file_result.unwrap()).unwrap();
     }
 
-    let function = |event|{client_event_callback(event)} ;
-    let dyn_function = Arc::new(function);
-    let callback = ClientEventListener::Callback(dyn_function);
-
     let connect_options = ConnectOptionsBuilder::new()
         .with_keep_alive_interval_seconds(Some(60))
         .with_client_id("HelloClient-wss")
@@ -164,7 +159,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let config = Mqtt5ClientOptionsBuilder::new()
         .with_offline_queue_policy(OfflineQueuePolicy::PreserveAll)
-        .with_default_event_listener(callback)
         .with_reconnect_period_jitter(ExponentialBackoffJitterType::None)
         .with_outbound_alias_resolver_factory(OutboundAliasResolverFactory::new_lru_factory(10))
         .build();

--- a/gneiss-mqtt-aws/src/lib.rs
+++ b/gneiss-mqtt-aws/src/lib.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Once started, the client will recurrently maintain a connection to the endpoint until
     // stop() is invoked
-    client.start()?;
+    client.start(None)?;
 
     // <do stuff with the client>
 
@@ -99,7 +99,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Once started, the client will recurrently maintain a connection to the endpoint until
     // stop() is invoked
-    client.start()?;
+    client.start(None)?;
 
     // <do stuff with the client>
 
@@ -150,7 +150,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Once started, the client will recurrently maintain a connection to the endpoint until
     // stop() is invoked
-    client.start()?;
+    client.start(None)?;
 
     // <do stuff with the client>
 
@@ -192,7 +192,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Once started, the client will recurrently maintain a connection to the endpoint until
     // stop() is invoked
-    client.start()?;
+    client.start(None)?;
 
     // <do stuff with the client>
 

--- a/gneiss-mqtt/CHANGELOG.md
+++ b/gneiss-mqtt/CHANGELOG.md
@@ -22,4 +22,5 @@ This document is currently hand-written and non-authoritative.
 * * removed all re-exports from top-level crate
 * * added public Into implementations for a few spec enums
 * * broker encode/decode functionality needed for testing wrapped in test feature checks
+* * default client event listener injection moved from client config to the start() client method
 

--- a/gneiss-mqtt/src/lib.rs
+++ b/gneiss-mqtt/src/lib.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Once started, the client will recurrently maintain a connection to the endpoint until
     // stop() is invoked
-    client.start()?;
+    client.start(None)?;
 
     // <do stuff with the client>
 


### PR DESCRIPTION
Move default event listener to start() invocation.  This makes it much easier to use the client from a listener callback by allowing closure capture (assuming the client is in an Arc)