### PR TITLE
Custom auth work

### DIFF
--- a/gneiss-mqtt-aws/CHANGELOG.md
+++ b/gneiss-mqtt-aws/CHANGELOG.md
@@ -7,3 +7,8 @@ This document is currently hand-written and non-authoritative.
 * * websockets via AWS sig4 support
 * * AWS IoT Custom Authentication support
 * * Initial crate documentation
+
+## 0.3.0
+* Custom Auth refactoring
+* * Reworked custom auth options to builder-based
+* * Added SDK/Version params (may remove later)

--- a/gneiss-mqtt-aws/CHANGELOG.md
+++ b/gneiss-mqtt-aws/CHANGELOG.md
@@ -12,3 +12,4 @@ This document is currently hand-written and non-authoritative.
 * Custom Auth refactoring
 * * Reworked custom auth options to builder-based
 * * Added SDK/Version params (may remove later)
+* * URI encode custom authorizer signatures when it's safe to do so

--- a/gneiss-mqtt-aws/src/lib.rs
+++ b/gneiss-mqtt-aws/src/lib.rs
@@ -416,9 +416,6 @@ impl AwsCustomAuthOptionsBuilder {
             params.push(format!("{}={}", authorizer_token_key_name.clone(), self.authorizer_token_key_value.as_ref().unwrap().clone()));
         }
 
-        params.push("SDK=gneiss-mqtt-aws".to_string());
-        params.push(format!("Version={}", GNEISS_MQTT_AWS_VERSION));
-
         params
     }
 

--- a/gneiss-mqtt-aws/src/lib.rs
+++ b/gneiss-mqtt-aws/src/lib.rs
@@ -253,7 +253,6 @@ use aws_credential_types::provider::ProvideCredentials;
 use aws_sigv4::http_request::{SessionTokenMode, sign, SignableBody, SignableRequest, SignatureLocation};
 use aws_sigv4::sign::v4;
 use aws_smithy_runtime_api::client::identity::Identity;
-use urlencoding::encode;
 
 pub(crate) const GNEISS_MQTT_AWS_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -728,11 +727,11 @@ async fn sign_websocket_upgrade_sigv4(request_builder: http::request::Builder, s
     let mut query_param_list = signing_instructions
         .params()
         .iter()
-        .map(|(key, value)| { format!("{}={}", encode(key), encode(value))})
+        .map(|(key, value)| { format!("{}={}", urlencoding::encode(key), urlencoding::encode(value))})
         .collect::<Vec<String>>();
 
     if let Some(session_token) = session_token {
-        query_param_list.push(format!("X-Amz-Security-Token={}", encode(session_token.as_str())));
+        query_param_list.push(format!("X-Amz-Security-Token={}", urlencoding::encode(session_token.as_str())));
     }
 
     let query_params = query_param_list.join("&");

--- a/gneiss-mqtt-aws/src/lib.rs
+++ b/gneiss-mqtt-aws/src/lib.rs
@@ -403,7 +403,14 @@ impl AwsCustomAuthOptionsBuilder {
         }
 
         if let Some(authorizer_signature) = &self.authorizer_signature {
-            params.push(format!("{}={}", CUSTOM_AUTH_SIGNATURE_QUERY_PARAM_NAME, authorizer_signature.clone()));
+            let final_signature =
+                if !authorizer_signature.contains('%') {
+                    urlencoding::encode(authorizer_signature).to_string()
+                } else {
+                    authorizer_signature.clone()
+                };
+
+            params.push(format!("{}={}", CUSTOM_AUTH_SIGNATURE_QUERY_PARAM_NAME, final_signature));
         }
 
         if let Some(authorizer_token_key_name) = &self.authorizer_token_key_name {

--- a/gneiss-mqtt-aws/src/lib.rs
+++ b/gneiss-mqtt-aws/src/lib.rs
@@ -254,8 +254,6 @@ use aws_sigv4::http_request::{SessionTokenMode, sign, SignableBody, SignableRequ
 use aws_sigv4::sign::v4;
 use aws_smithy_runtime_api::client::identity::Identity;
 
-pub(crate) const GNEISS_MQTT_AWS_VERSION: &str = env!("CARGO_PKG_VERSION");
-
 /// Struct holding all configuration relevant to connecting an MQTT client to AWS IoT Core
 /// over websockets using a Sigv4-signed websocket handshake for authentication
 #[derive(Clone, Debug)]


### PR DESCRIPTION
* URI encode authorizer signatures when safe
* refactor custom auth configuration - authorizer is optional and username/pass become fluent builder methods
