### PR TITLE
Feature tokio

### DIFF
--- a/elasti-gneiss-aws/Cargo.toml
+++ b/elasti-gneiss-aws/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 
 [dependencies]
 elasti-gneiss-core = { path = "../elasti-gneiss-core" }
-gneiss-mqtt = { path = "../gneiss-mqtt" }
-gneiss-mqtt-aws = { path = "../gneiss-mqtt-aws" }
+gneiss-mqtt = { path = "../gneiss-mqtt", features = ["tokio-rustls", "tokio-native-tls", "tokio-websockets"] }
+gneiss-mqtt-aws = { path = "../gneiss-mqtt-aws", features = ["tokio-rustls", "tokio-native-tls", "tokio-websockets"] }
 tokio = { version = "1", features = ["full"] }
 simplelog = { version = "0.12" }
 argh = { version = "0.1" }

--- a/elasti-gneiss-aws/src/main.rs
+++ b/elasti-gneiss-aws/src/main.rs
@@ -68,7 +68,7 @@ struct CommandLineArgs {
     signing_region: Option<String>
 }
 
-async fn build_client(connect_config: ConnectOptions, client_config: Mqtt5ClientOptions, runtime: &Handle, args: &CommandLineArgs) -> ElastiResult<Mqtt5Client> {
+async fn build_client(connect_config: ConnectOptions, client_config: MqttClientOptions, runtime: &Handle, args: &CommandLineArgs) -> ElastiResult<Mqtt5Client> {
     let uri_string = args.endpoint_uri.clone();
 
     let url_parse_result = Url::parse(&uri_string);
@@ -159,7 +159,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let connect_options = ConnectOptionsBuilder::new().build();
 
-    let config = Mqtt5ClientOptionsBuilder::new()
+    let config = MqttClientOptionsBuilder::new()
         .with_offline_queue_policy(OfflineQueuePolicy::PreserveAll)
         .with_reconnect_period_jitter(ExponentialBackoffJitterType::Uniform)
         .build();

--- a/elasti-gneiss-aws/src/main.rs
+++ b/elasti-gneiss-aws/src/main.rs
@@ -6,7 +6,7 @@
 use std::fs::File;
 use argh::FromArgs;
 use elasti_gneiss_core::{ElastiError, ElastiResult, main_loop};
-use gneiss_mqtt::client::Mqtt5Client;
+use gneiss_mqtt::client::AsyncMqttClient;
 use gneiss_mqtt::config::*;
 use gneiss_mqtt_aws::{AwsClientBuilder, AwsCustomAuthOptionsBuilder, WebsocketSigv4OptionsBuilder};
 use simplelog::{LevelFilter, WriteLogger};
@@ -68,7 +68,7 @@ struct CommandLineArgs {
     signing_region: Option<String>
 }
 
-async fn build_client(connect_config: ConnectOptions, client_config: MqttClientOptions, runtime: &Handle, args: &CommandLineArgs) -> ElastiResult<Mqtt5Client> {
+async fn build_client(connect_config: ConnectOptions, client_config: MqttClientOptions, runtime: &Handle, args: &CommandLineArgs) -> ElastiResult<AsyncMqttClient> {
     let uri_string = args.endpoint_uri.clone();
 
     let url_parse_result = Url::parse(&uri_string);

--- a/elasti-gneiss-aws/src/main.rs
+++ b/elasti-gneiss-aws/src/main.rs
@@ -6,7 +6,7 @@
 use std::fs::File;
 use argh::FromArgs;
 use elasti_gneiss_core::{ElastiError, ElastiResult, main_loop};
-use gneiss_mqtt::client::AsyncMqttClient;
+use gneiss_mqtt::client::AsyncGneissClient;
 use gneiss_mqtt::config::*;
 use gneiss_mqtt_aws::{AwsClientBuilder, AwsCustomAuthOptionsBuilder, WebsocketSigv4OptionsBuilder};
 use simplelog::{LevelFilter, WriteLogger};
@@ -68,7 +68,7 @@ struct CommandLineArgs {
     signing_region: Option<String>
 }
 
-async fn build_client(connect_config: ConnectOptions, client_config: MqttClientOptions, runtime: &Handle, args: &CommandLineArgs) -> ElastiResult<AsyncMqttClient> {
+async fn build_client(connect_config: ConnectOptions, client_config: MqttClientOptions, runtime: &Handle, args: &CommandLineArgs) -> ElastiResult<AsyncGneissClient> {
     let uri_string = args.endpoint_uri.clone();
 
     let url_parse_result = Url::parse(&uri_string);

--- a/elasti-gneiss-aws/src/main.rs
+++ b/elasti-gneiss-aws/src/main.rs
@@ -91,7 +91,7 @@ async fn build_client(connect_config: ConnectOptions, client_config: MqttClientO
                 Ok(AwsClientBuilder::new_direct_with_mtls_from_fs(&endpoint, args.cert.as_ref().unwrap(), args.key.as_ref().unwrap(), capath)?
                     .with_connect_options(connect_config)
                     .with_client_options(client_config)
-                    .build(runtime)?)
+                    .build_tokio(runtime)?)
             } else {
                 println!("ERROR: aws-mqtts scheme requires certification and private key fields for mTLS");
                 Err(ElastiError::MissingArguments("--cert, --key"))
@@ -123,7 +123,7 @@ async fn build_client(connect_config: ConnectOptions, client_config: MqttClientO
             Ok(AwsClientBuilder::new_direct_with_custom_auth(&endpoint, config.build(), capath)?
                 .with_connect_options(connect_config)
                 .with_client_options(client_config)
-                .build(runtime)?)
+                .build_tokio(runtime)?)
         }
         "aws-wss" => {
             let signing_region = args.signing_region.clone().unwrap_or("us-east-1".to_string());
@@ -133,7 +133,7 @@ async fn build_client(connect_config: ConnectOptions, client_config: MqttClientO
             Ok(AwsClientBuilder::new_websockets_with_sigv4(&endpoint, sigv4_options, capath)?
                 .with_connect_options(connect_config)
                 .with_client_options(client_config)
-                .build(runtime)?)
+                .build_tokio(runtime)?)
         }
         _ => {
             Err(ElastiError::UnsupportedUriScheme(scheme))

--- a/elasti-gneiss-core/src/lib.rs
+++ b/elasti-gneiss-core/src/lib.rs
@@ -175,14 +175,14 @@ pub fn client_event_callback(event: Arc<ClientEvent>) {
     }
 }
 
-fn handle_start(client: &AsyncMqttClient, _: StartArgs) {
+fn handle_start(client: &AsyncGneissClient, _: StartArgs) {
     let function = |event|{ client_event_callback(event) };
     let listener_callback = Arc::new(function);
 
     let _ = client.start(Some(listener_callback));
 }
 
-fn handle_stop(client: &AsyncMqttClient, args: StopArgs) {
+fn handle_stop(client: &AsyncGneissClient, args: StopArgs) {
     let mut stop_options_builder = StopOptionsBuilder::new();
 
     if let Some(reason_code_u8) = args.reason_code {
@@ -197,11 +197,11 @@ fn handle_stop(client: &AsyncMqttClient, args: StopArgs) {
     let _ = client.stop(Some(stop_options_builder.build()));
 }
 
-fn handle_close(client: &AsyncMqttClient, _ : CloseArgs) {
+fn handle_close(client: &AsyncGneissClient, _ : CloseArgs) {
     let _ = client.close();
 }
 
-async fn handle_publish(client: &AsyncMqttClient, args: PublishArgs) {
+async fn handle_publish(client: &AsyncGneissClient, args: PublishArgs) {
 
     let qos_result = QualityOfService::try_from(args.qos);
     if qos_result.is_err() {
@@ -229,7 +229,7 @@ async fn handle_publish(client: &AsyncMqttClient, args: PublishArgs) {
     }
 }
 
-async fn handle_subscribe(client: &AsyncMqttClient, args: SubscribeArgs) {
+async fn handle_subscribe(client: &AsyncGneissClient, args: SubscribeArgs) {
     let qos_result = QualityOfService::try_from(args.qos);
     if qos_result.is_err() {
         println!("Invalid input!  Qos must be 0, 1, or 2");
@@ -252,7 +252,7 @@ async fn handle_subscribe(client: &AsyncMqttClient, args: SubscribeArgs) {
     }
 }
 
-async fn handle_unsubscribe(client: &AsyncMqttClient, args: UnsubscribeArgs) {
+async fn handle_unsubscribe(client: &AsyncGneissClient, args: UnsubscribeArgs) {
 
     let unsubscribe = UnsubscribePacket::builder().with_topic_filter(args.topic_filter).build();
 
@@ -268,7 +268,7 @@ async fn handle_unsubscribe(client: &AsyncMqttClient, args: UnsubscribeArgs) {
     }
 }
 
-async fn handle_input(value: String, client: &AsyncMqttClient) -> bool {
+async fn handle_input(value: String, client: &AsyncGneissClient) -> bool {
     let args : Vec<&str> = value.split_whitespace().collect();
     if args.is_empty() {
         println!("Invalid input!");
@@ -295,7 +295,7 @@ async fn handle_input(value: String, client: &AsyncMqttClient) -> bool {
     false
 }
 
-pub async fn main_loop(client: AsyncMqttClient) {
+pub async fn main_loop(client: AsyncGneissClient) {
 
     let stdin = tokio::io::stdin();
     let mut lines = BufReader::new(stdin).lines();

--- a/elasti-gneiss-core/src/lib.rs
+++ b/elasti-gneiss-core/src/lib.rs
@@ -175,14 +175,14 @@ pub fn client_event_callback(event: Arc<ClientEvent>) {
     }
 }
 
-fn handle_start(client: &Mqtt5Client, _: StartArgs) {
+fn handle_start(client: &AsyncMqttClient, _: StartArgs) {
     let function = |event|{ client_event_callback(event) };
     let listener_callback = Arc::new(function);
 
     let _ = client.start(Some(listener_callback));
 }
 
-fn handle_stop(client: &Mqtt5Client, args: StopArgs) {
+fn handle_stop(client: &AsyncMqttClient, args: StopArgs) {
     let mut stop_options_builder = StopOptionsBuilder::new();
 
     if let Some(reason_code_u8) = args.reason_code {
@@ -197,11 +197,11 @@ fn handle_stop(client: &Mqtt5Client, args: StopArgs) {
     let _ = client.stop(Some(stop_options_builder.build()));
 }
 
-fn handle_close(client: &Mqtt5Client, _ : CloseArgs) {
+fn handle_close(client: &AsyncMqttClient, _ : CloseArgs) {
     let _ = client.close();
 }
 
-async fn handle_publish(client: &Mqtt5Client, args: PublishArgs) {
+async fn handle_publish(client: &AsyncMqttClient, args: PublishArgs) {
 
     let qos_result = QualityOfService::try_from(args.qos);
     if qos_result.is_err() {
@@ -229,7 +229,7 @@ async fn handle_publish(client: &Mqtt5Client, args: PublishArgs) {
     }
 }
 
-async fn handle_subscribe(client: &Mqtt5Client, args: SubscribeArgs) {
+async fn handle_subscribe(client: &AsyncMqttClient, args: SubscribeArgs) {
     let qos_result = QualityOfService::try_from(args.qos);
     if qos_result.is_err() {
         println!("Invalid input!  Qos must be 0, 1, or 2");
@@ -252,7 +252,7 @@ async fn handle_subscribe(client: &Mqtt5Client, args: SubscribeArgs) {
     }
 }
 
-async fn handle_unsubscribe(client: &Mqtt5Client, args: UnsubscribeArgs) {
+async fn handle_unsubscribe(client: &AsyncMqttClient, args: UnsubscribeArgs) {
 
     let unsubscribe = UnsubscribePacket::builder().with_topic_filter(args.topic_filter).build();
 
@@ -268,7 +268,7 @@ async fn handle_unsubscribe(client: &Mqtt5Client, args: UnsubscribeArgs) {
     }
 }
 
-async fn handle_input(value: String, client: &Mqtt5Client) -> bool {
+async fn handle_input(value: String, client: &AsyncMqttClient) -> bool {
     let args : Vec<&str> = value.split_whitespace().collect();
     if args.is_empty() {
         println!("Invalid input!");
@@ -295,7 +295,7 @@ async fn handle_input(value: String, client: &Mqtt5Client) -> bool {
     false
 }
 
-pub async fn main_loop(client: Mqtt5Client) {
+pub async fn main_loop(client: AsyncMqttClient) {
 
     let stdin = tokio::io::stdin();
     let mut lines = BufReader::new(stdin).lines();

--- a/elasti-gneiss/Cargo.toml
+++ b/elasti-gneiss/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gneiss-mqtt = { path = "../gneiss-mqtt", features = ["rustls"] }
+gneiss-mqtt = { path = "../gneiss-mqtt", features = ["tokio-rustls", "tokio-native-tls", "tokio-websockets"] }
 elasti-gneiss-core = { path = "../elasti-gneiss-core" }
 tokio = { version = "1", features = ["full"] }
 simplelog = { version = "0.12" }

--- a/elasti-gneiss/src/main.rs
+++ b/elasti-gneiss/src/main.rs
@@ -6,7 +6,7 @@
 use std::fs::File;
 use argh::FromArgs;
 use elasti_gneiss_core::{ElastiError, ElastiResult, main_loop};
-use gneiss_mqtt::client::AsyncMqttClient;
+use gneiss_mqtt::client::AsyncGneissClient;
 use gneiss_mqtt::config::*;
 use simplelog::{LevelFilter, WriteLogger};
 use std::path::PathBuf;
@@ -48,7 +48,7 @@ struct CommandLineArgs {
     http_proxy_uri: Option<String>
 }
 
-fn build_client(connect_options: ConnectOptions, client_config: MqttClientOptions, runtime: &Handle, args: &CommandLineArgs) -> ElastiResult<AsyncMqttClient> {
+fn build_client(connect_options: ConnectOptions, client_config: MqttClientOptions, runtime: &Handle, args: &CommandLineArgs) -> ElastiResult<AsyncGneissClient> {
     let uri_string = args.endpoint_uri.clone();
 
     let url_parse_result = Url::parse(&args.endpoint_uri);

--- a/elasti-gneiss/src/main.rs
+++ b/elasti-gneiss/src/main.rs
@@ -132,7 +132,7 @@ fn build_client(connect_options: ConnectOptions, client_config: MqttClientOption
         _ => {}
     }
 
-    Ok(builder.build(runtime)?)
+    Ok(builder.build_tokio(runtime)?)
 }
 
 #[tokio::main]

--- a/elasti-gneiss/src/main.rs
+++ b/elasti-gneiss/src/main.rs
@@ -6,7 +6,7 @@
 use std::fs::File;
 use argh::FromArgs;
 use elasti_gneiss_core::{ElastiError, ElastiResult, main_loop};
-use gneiss_mqtt::client::Mqtt5Client;
+use gneiss_mqtt::client::AsyncMqttClient;
 use gneiss_mqtt::config::*;
 use simplelog::{LevelFilter, WriteLogger};
 use std::path::PathBuf;
@@ -48,7 +48,7 @@ struct CommandLineArgs {
     http_proxy_uri: Option<String>
 }
 
-fn build_client(connect_options: ConnectOptions, client_config: MqttClientOptions, runtime: &Handle, args: &CommandLineArgs) -> ElastiResult<Mqtt5Client> {
+fn build_client(connect_options: ConnectOptions, client_config: MqttClientOptions, runtime: &Handle, args: &CommandLineArgs) -> ElastiResult<AsyncMqttClient> {
     let uri_string = args.endpoint_uri.clone();
 
     let url_parse_result = Url::parse(&args.endpoint_uri);

--- a/elasti-gneiss/src/main.rs
+++ b/elasti-gneiss/src/main.rs
@@ -48,7 +48,7 @@ struct CommandLineArgs {
     http_proxy_uri: Option<String>
 }
 
-fn build_client(connect_options: ConnectOptions, client_config: Mqtt5ClientOptions, runtime: &Handle, args: &CommandLineArgs) -> ElastiResult<Mqtt5Client> {
+fn build_client(connect_options: ConnectOptions, client_config: MqttClientOptions, runtime: &Handle, args: &CommandLineArgs) -> ElastiResult<Mqtt5Client> {
     let uri_string = args.endpoint_uri.clone();
 
     let url_parse_result = Url::parse(&args.endpoint_uri);
@@ -157,7 +157,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_rejoin_session_policy(RejoinSessionPolicy::PostSuccess)
         .build();
 
-    let config = Mqtt5ClientOptionsBuilder::new()
+    let config = MqttClientOptionsBuilder::new()
         .with_offline_queue_policy(OfflineQueuePolicy::PreserveAll)
         .with_reconnect_period_jitter(ExponentialBackoffJitterType::None)
         .with_outbound_alias_resolver_factory(OutboundAliasResolverFactory::new_lru_factory(10))

--- a/gneiss-mqtt-aws/Cargo.toml
+++ b/gneiss-mqtt-aws/Cargo.toml
@@ -16,20 +16,19 @@ features = []
 all-features = true
 
 [features]
-default = [] # eventually tokio, rustls
+default = []
 testing = [] # enable when running tests to also run environmentally-controlled integration tests
-rustls = [ "gneiss-mqtt/rustls" ]
-native-tls = [ "gneiss-mqtt/native-tls" ]
-websockets = [
-    "gneiss-mqtt/websockets",
+tokio-rustls = [ "dep:tokio", "gneiss-mqtt/tokio-rustls" ]
+tokio-native-tls = [ "dep:tokio", "gneiss-mqtt/tokio-native-tls" ]
+tokio-websockets = [
+    "dep:tokio",
+    "gneiss-mqtt/tokio-websockets",
     "dep:aws-config",
     "dep:aws-credential-types",
     "dep:aws-sigv4",
     "dep:aws-smithy-runtime-api",
     "dep:http",
 ]
-# Eventually: tokio, rustls, nativetls, async_std, threaded, http_proxy, websockets
-# Consider: mqtt311, mqtt5, log
 
 [dependencies]
 aws-config = { version = "1", optional = true }
@@ -38,6 +37,6 @@ aws-sigv4 = { version = "1", optional = true }
 aws-smithy-runtime-api = { version = "1", optional = true }
 gneiss-mqtt = { path = "../gneiss-mqtt" }
 http = { version = "0.2", optional = true }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["full"], optional = true }
 urlencoding = { version = "2" }
 uuid = { version = "1", features = [ "v4", "fast-rng" ] }

--- a/gneiss-mqtt-aws/src/lib.rs
+++ b/gneiss-mqtt-aws/src/lib.rs
@@ -485,7 +485,7 @@ pub struct AwsClientBuilder {
     auth_type: AuthType,
     custom_auth_options: Option<AwsCustomAuthOptions>,
     connect_options: Option<ConnectOptions>,
-    client_options: Option<Mqtt5ClientOptions>,
+    client_options: Option<MqttClientOptions>,
     tls_options_builder: TlsOptionsBuilder,
     #[cfg(feature = "websockets")]
     websocket_sigv4_options: Option<WebsocketSigv4Options>,
@@ -629,7 +629,7 @@ impl AwsClientBuilder {
     }
 
     /// Registers a set of client configuration options with the builder.
-    pub fn with_client_options(mut self, client_options: Mqtt5ClientOptions) -> Self {
+    pub fn with_client_options(mut self, client_options: MqttClientOptions) -> Self {
         self.client_options = Some(client_options);
         self
     }
@@ -685,7 +685,7 @@ impl AwsClientBuilder {
             if let Some(options) = &self.client_options {
                 options.clone()
             } else {
-                Mqtt5ClientOptionsBuilder::new().build()
+                MqttClientOptionsBuilder::new().build()
             };
 
         let tls_options = self.build_tls_options()?;

--- a/gneiss-mqtt-aws/src/lib.rs
+++ b/gneiss-mqtt-aws/src/lib.rs
@@ -245,7 +245,7 @@ different combinations expected by users.
 
 #![warn(missing_docs)]
 
-use gneiss_mqtt::client::{AsyncMqttClient};
+use gneiss_mqtt::client::{AsyncGneissClient};
 use gneiss_mqtt::config::*;
 #[allow(unused_imports)]
 use gneiss_mqtt::error::{MqttError, MqttResult};
@@ -671,7 +671,7 @@ impl AwsClientBuilder {
 
     /// Creates a new MQTT5 client from all of the configuration options registered with the
     /// builder.
-    pub fn build(&self, runtime: &Handle) -> MqttResult<AsyncMqttClient> {
+    pub fn build(&self, runtime: &Handle) -> MqttResult<AsyncGneissClient> {
         let user_connect_options =
             if let Some(options) = &self.connect_options {
                 options.clone()

--- a/gneiss-mqtt-aws/src/lib.rs
+++ b/gneiss-mqtt-aws/src/lib.rs
@@ -62,7 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // In the common case, you will not need a root CA certificate
     let client =
         AwsClientBuilder::new_direct_with_mtls_from_fs(endpoint, cert_path, key_path, None)?
-            .build(&Handle::current())?;
+            .build_tokio(&Handle::current())?;
 
     // Once started, the client will recurrently maintain a connection to the endpoint until
     // stop() is invoked

--- a/gneiss-mqtt-aws/src/lib.rs
+++ b/gneiss-mqtt-aws/src/lib.rs
@@ -245,8 +245,8 @@ different combinations expected by users.
 
 #![warn(missing_docs)]
 
+use gneiss_mqtt::client::{AsyncMqttClient};
 use gneiss_mqtt::config::*;
-use gneiss_mqtt::client::Mqtt5Client;
 #[allow(unused_imports)]
 use gneiss_mqtt::error::{MqttError, MqttResult};
 use std::fmt::Write;
@@ -671,7 +671,7 @@ impl AwsClientBuilder {
 
     /// Creates a new MQTT5 client from all of the configuration options registered with the
     /// builder.
-    pub fn build(&self, runtime: &Handle) -> MqttResult<Mqtt5Client> {
+    pub fn build(&self, runtime: &Handle) -> MqttResult<AsyncMqttClient> {
         let user_connect_options =
             if let Some(options) = &self.connect_options {
                 options.clone()
@@ -882,7 +882,7 @@ mod testing {
     }
 
     async fn do_connect_test(builder: AwsClientBuilder) -> MqttResult<()> {
-        let client = std::sync::Arc::new(builder.build(&Handle::current())?);
+        let client = builder.build(&Handle::current())?;
 
         let waiter_config = ClientEventWaiterOptions {
             wait_type: ClientEventWaitType::Predicate(Box::new(|ev| {

--- a/gneiss-mqtt/CHANGELOG.md
+++ b/gneiss-mqtt/CHANGELOG.md
@@ -30,6 +30,9 @@ This document is currently hand-written and non-authoritative.
 * * timeout polish
 * * * remove connack timeout as a setting, connect timeout now covers the end-to-end interval from socket open to connack receipt
 * * * fixed an edge case when ping timeout is larger than half the keep alive setting
+* * AsyncClient interface trait added
+* * Mqtt5Client renamed
+* * Client construction yields an Arc-wrapped type
 * TLS
 * * alpn values changed to a string representation
 * * Rustls configuration build errors now a wrapped error
@@ -37,3 +40,4 @@ This document is currently hand-written and non-authoritative.
 * * Rustls support feature-gated
 * * Native-tls support added and feature-gated
 * * Websocket support feature-gated
+* * Tokio client feature-gated

--- a/gneiss-mqtt/Cargo.toml
+++ b/gneiss-mqtt/Cargo.toml
@@ -16,11 +16,12 @@ features = []
 all-features = true
 
 [features]
-default = [] # remove soon
+default = ["tokio"] # remove soon
 testing = [] # enables environmentally-controlled integration tests and long-running tests (30+ seconds) that check reconnect, backoff, etc...
 rustls = ["dep:rustls", "dep:rustls-native-certs", "dep:rustls-pemfile", "dep:rustls-pki-types", "dep:tokio-rustls"]
 native-tls = ["dep:native-tls", "dep:tokio-native-tls"]
 websockets = ["dep:http", "dep:tungstenite", "dep:tokio-tungstenite", "dep:stream-ws"]
+tokio = ["dep:tokio"]
 
 # Eventually: tokio, rustls, nativetls, async_std, threaded, http_proxy, websockets
 # Consider: mqtt311, mqtt5, log
@@ -41,7 +42,7 @@ rustls-native-certs = { version = "0.7", optional = true }
 rustls-pemfile = { version = "2", optional = true }
 rustls-pki-types = { version = "1", optional = true }
 stream-ws = { version = "0.1.1", features = ["tungstenite", "tokio"], optional = true }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["full"], optional = true }
 tokio-native-tls = { version = "0.3.1", optional = true}
 tokio-rustls = { version = "0.25", optional = true }
 tokio-tungstenite = { version = "0.20" , optional = true }

--- a/gneiss-mqtt/Cargo.toml
+++ b/gneiss-mqtt/Cargo.toml
@@ -16,15 +16,12 @@ features = []
 all-features = true
 
 [features]
-default = ["tokio"] # remove soon
+default = [] # remove soon
 testing = [] # enables environmentally-controlled integration tests and long-running tests (30+ seconds) that check reconnect, backoff, etc...
 rustls = ["dep:rustls", "dep:rustls-native-certs", "dep:rustls-pemfile", "dep:rustls-pki-types", "dep:tokio-rustls"]
 native-tls = ["dep:native-tls", "dep:tokio-native-tls"]
 websockets = ["dep:http", "dep:tungstenite", "dep:tokio-tungstenite", "dep:stream-ws"]
 tokio = ["dep:tokio"]
-
-# Eventually: tokio, rustls, nativetls, async_std, threaded, http_proxy, websockets
-# Consider: mqtt311, mqtt5, log
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/gneiss-mqtt/Cargo.toml
+++ b/gneiss-mqtt/Cargo.toml
@@ -16,11 +16,10 @@ features = []
 all-features = true
 
 [features]
-default = [] # remove soon
 testing = [] # enables environmentally-controlled integration tests and long-running tests (30+ seconds) that check reconnect, backoff, etc...
-rustls = ["dep:rustls", "dep:rustls-native-certs", "dep:rustls-pemfile", "dep:rustls-pki-types", "dep:tokio-rustls"]
-native-tls = ["dep:native-tls", "dep:tokio-native-tls"]
-websockets = ["dep:http", "dep:tungstenite", "dep:tokio-tungstenite", "dep:stream-ws"]
+tokio-rustls = ["tokio", "dep:rustls", "dep:rustls-native-certs", "dep:rustls-pemfile", "dep:rustls-pki-types", "dep:tokio-rustls"]
+tokio-native-tls = ["tokio", "dep:native-tls", "dep:tokio-native-tls"]
+tokio-websockets = ["tokio", "dep:http", "dep:tungstenite", "dep:tokio-tungstenite", "dep:stream-ws"]
 tokio = ["dep:tokio"]
 
 [dev-dependencies]

--- a/gneiss-mqtt/src/client.rs
+++ b/gneiss-mqtt/src/client.rs
@@ -23,9 +23,6 @@ use std::pin::Pin;
 use std::sync::{Arc};
 use std::time::{Duration, Instant};
 
-// async choice conditional
-//use crate::features::gneiss_tokio::*;
-
 /// Additional client options applicable to an MQTT Publish operation
 #[derive(Debug, Default)]
 pub struct PublishOptions {
@@ -1103,7 +1100,7 @@ pub mod waiter {
 /// Direct client construction is messy due to the different possibilities for TLS, async runtime,
 /// etc...  We encourage you to use the various client builders in this crate, or in other crates,
 /// to simplify this process.
-pub trait AsyncClient {
+pub trait AsyncMqttClient {
 
     /// Signals the client that it should attempt to recurrently maintain a connection to
     /// the broker endpoint it has been configured with.
@@ -1162,4 +1159,4 @@ pub trait AsyncClient {
 /// Direct client construction is messy due to the different possibilities for TLS, async runtime,
 /// etc...  We encourage you to use the various client builders in this crate, or in other crates,
 /// to simplify this process.
-pub type AsyncMqttClient = Arc<dyn AsyncClient + Send + Sync>;
+pub type AsyncGneissClient = Arc<dyn AsyncMqttClient + Send + Sync>;

--- a/gneiss-mqtt/src/client.rs
+++ b/gneiss-mqtt/src/client.rs
@@ -529,7 +529,7 @@ impl Display for ClientImplState {
     }
 }
 
-pub(crate) type CallbackSpawnerFunction = Box<dyn Fn(Arc<ClientEvent>, Arc<ClientEventListenerCallback>) -> () + Send + Sync>;
+pub(crate) type CallbackSpawnerFunction = Box<dyn Fn(Arc<ClientEvent>, Arc<ClientEventListenerCallback>) + Send + Sync>;
 
 pub(crate) struct MqttClientImpl {
     protocol_state: ProtocolState,

--- a/gneiss-mqtt/src/client.rs
+++ b/gneiss-mqtt/src/client.rs
@@ -10,10 +10,8 @@ Module containing the public MQTT client and associated types necessary to invok
 use crate::config::*;
 use crate::error::{MqttError, MqttResult};
 use crate::mqtt::*;
-use crate::mqtt::disconnect::validate_disconnect_packet_outbound;
 use crate::mqtt::utils::*;
 use crate::protocol::*;
-use crate::validate::*;
 
 use log::*;
 use rand::Rng;
@@ -22,11 +20,11 @@ use std::fmt::{Debug, Display, Formatter};
 use std::future::Future;
 use std::mem;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc};
 use std::time::{Duration, Instant};
 
 // async choice conditional
-use crate::features::gneiss_tokio::*;
+//use crate::features::gneiss_tokio::*;
 
 /// Additional client options applicable to an MQTT Publish operation
 #[derive(Debug, Default)]
@@ -478,131 +476,6 @@ pub struct ListenerHandle {
     pub(crate) id: u64
 }
 
-/// A network client that functions as a thin wrapper over the MQTT5 protocol.
-///
-/// A client is always in one of two states:
-/// * Stopped - the client is not connected and will perform no work
-/// * Not Stopped - the client will continually attempt to maintain a connection to the configured broker.
-///
-/// The start() and stop() APIs toggle between these two states.
-///
-/// The client will use configurable exponential backoff with jitter when re-establishing connections.
-///
-/// Regardless of the client's state, you may always safely invoke MQTT operations on it, but
-/// whether or not they are rejected (due to no connection) is a function of client configuration.
-///
-/// There are no mutable functions in the client API, so you can safely share it amongst threads,
-/// runtimes/tasks, etc... by wrapping a newly-constructed client in an Arc.
-///
-/// Submitted operations are placed in a queue where they remain until they reach the head.  At
-/// that point, the operation's packet is assigned a packet id (if appropriate) and encoded and
-/// written to the socket.
-///
-/// Direct client construction is messy due to the different possibilities for TLS, async runtime,
-/// etc...  We encourage you to use the various client builders in this crate, or in other crates,
-/// to simplify this process.
-pub struct Mqtt5Client {
-    pub(crate) user_state: UserRuntimeState,
-
-    pub(crate) listener_id_allocator: Mutex<u64>,
-}
-
-impl Mqtt5Client {
-
-    /// Signals the client that it should attempt to recurrently maintain a connection to
-    /// the broker endpoint it has been configured with.
-    pub fn start(&self, default_listener: Option<Arc<ClientEventListenerCallback>>) -> MqttResult<()> {
-        info!("client start invoked");
-        self.user_state.try_send(OperationOptions::Start(default_listener))
-    }
-
-    /// Signals the client that it should close any current connection it has and enter the
-    /// Stopped state, where it does nothing.
-    pub fn stop(&self, options: Option<StopOptions>) -> MqttResult<()> {
-        info!("client stop invoked {} a disconnect packet", if options.as_ref().is_some_and(|opts| { opts.disconnect.is_some()}) { "with" } else { "without" });
-        let options = options.unwrap_or_default();
-
-        if let Some(disconnect) = &options.disconnect {
-            validate_disconnect_packet_outbound(disconnect)?;
-        }
-
-        let mut stop_options_internal = StopOptionsInternal {
-            ..Default::default()
-        };
-
-        if options.disconnect.is_some() {
-            stop_options_internal.disconnect = Some(Box::new(MqttPacket::Disconnect(options.disconnect.unwrap())));
-        }
-
-        self.user_state.try_send(OperationOptions::Stop(stop_options_internal))
-    }
-
-    /// Signals the client that it should clean up all internal resources (connection, channels,
-    /// runtime tasks, etc...) and enter a terminal state that cannot be escaped.  Useful to ensure
-    /// a full resource wipe.  If just `stop()` is used then the client will continue to track
-    /// MQTT session state internally.
-    pub fn close(&self) -> MqttResult<()> {
-        info!("client close invoked; no further operations allowed");
-        self.user_state.try_send(OperationOptions::Shutdown())
-    }
-
-    /// Submits a Publish operation to the client's operation queue.  The publish will be sent to
-    /// the broker when it reaches the head of the queue and the client is connected.
-    pub fn publish(&self, packet: PublishPacket, options: Option<PublishOptions>) -> Pin<Box<PublishResultFuture>> {
-        debug!("Publish operation submitted");
-        let boxed_packet = Box::new(MqttPacket::Publish(packet));
-        if let Err(error) = validate_packet_outbound(&boxed_packet) {
-            return Box::pin(async move { Err(error) });
-        }
-
-        submit_async_client_operation!(self, Publish, PublishOptionsInternal, options, boxed_packet)
-    }
-
-    /// Submits a Subscribe operation to the client's operation queue.  The subscribe will be sent to
-    /// the broker when it reaches the head of the queue and the client is connected.
-    pub fn subscribe(&self, packet: SubscribePacket, options: Option<SubscribeOptions>) -> Pin<Box<SubscribeResultFuture>> {
-        debug!("Subscribe operation submitted");
-        let boxed_packet = Box::new(MqttPacket::Subscribe(packet));
-        if let Err(error) = validate_packet_outbound(&boxed_packet) {
-            return Box::pin(async move { Err(error) });
-        }
-
-        submit_async_client_operation!(self, Subscribe, SubscribeOptionsInternal, options, boxed_packet)
-    }
-
-    /// Submits an Unsubscribe operation to the client's operation queue.  The unsubscribe will be sent to
-    /// the broker when it reaches the head of the queue and the client is connected.
-    pub fn unsubscribe(&self, packet: UnsubscribePacket, options: Option<UnsubscribeOptions>) -> Pin<Box<UnsubscribeResultFuture>> {
-        debug!("Unsubscribe operation submitted");
-        let boxed_packet = Box::new(MqttPacket::Unsubscribe(packet));
-        if let Err(error) = validate_packet_outbound(&boxed_packet) {
-            return Box::pin(async move { Err(error) });
-        }
-
-        submit_async_client_operation!(self, Unsubscribe, UnsubscribeOptionsInternal, options, boxed_packet)
-    }
-
-    /// Adds an additional listener to the events emitted by this client.  This is useful when
-    /// multiple higher-level constructs are sharing the same MQTT client.
-    pub fn add_event_listener(&self, listener: ClientEventListener) -> MqttResult<ListenerHandle> {
-        debug!("AddListener operation submitted");
-        let mut current_id = self.listener_id_allocator.lock().unwrap();
-        let listener_id = *current_id;
-        *current_id += 1;
-
-        self.user_state.try_send(OperationOptions::AddListener(listener_id, listener))?;
-
-        Ok(ListenerHandle {
-            id: listener_id
-        })
-    }
-
-    /// Removes a listener from this client's set of event listeners.
-    pub fn remove_event_listener(&self, listener: ListenerHandle) -> MqttResult<()> {
-        debug!("RemoveListener operation submitted");
-        self.user_state.try_send(OperationOptions::RemoveListener(listener.id))
-    }
-}
 
 pub(crate) type ResponseHandler<T> = Box<dyn FnOnce(T) -> MqttResult<()> + Send + Sync>;
 
@@ -659,7 +532,9 @@ impl Display for ClientImplState {
     }
 }
 
-pub(crate) struct Mqtt5ClientImpl {
+pub(crate) type CallbackSpawnerFunction = Box<dyn Fn(Arc<ClientEvent>, Arc<ClientEventListenerCallback>) -> () + Send + Sync>;
+
+pub(crate) struct MqttClientImpl {
     protocol_state: ProtocolState,
     listeners: HashMap<u64, ClientEventListener>,
 
@@ -680,12 +555,14 @@ pub(crate) struct Mqtt5ClientImpl {
     reconnect_options: ReconnectOptions,
 
     connect_timeout: Duration,
+
+    callback_spawner: CallbackSpawnerFunction
 }
 
 
-impl Mqtt5ClientImpl {
+impl MqttClientImpl {
 
-    pub(crate) fn new(client_config: Mqtt5ClientOptions, connect_config: ConnectOptions) -> Self {
+    pub(crate) fn new(client_config: MqttClientOptions, connect_config: ConnectOptions, callback_spawner: CallbackSpawnerFunction) -> Self {
         debug!("Creating new MQTT client - client options: {:?}", client_config);
         debug!("Creating new MQTT client - connect options: {:?}", connect_config);
 
@@ -697,7 +574,7 @@ impl Mqtt5ClientImpl {
             outbound_alias_resolver: client_config.outbound_alias_resolver_factory.map(|f| { f() })
         };
 
-        let mut client_impl = Mqtt5ClientImpl {
+        let mut client_impl = MqttClientImpl {
             protocol_state: ProtocolState::new(state_config),
             listeners: HashMap::new(),
             current_state: ClientImplState::Stopped,
@@ -711,7 +588,8 @@ impl Mqtt5ClientImpl {
             successful_connect_time: None,
             next_reconnect_period: client_config.reconnect_options.base_reconnect_period,
             reconnect_options: client_config.reconnect_options,
-            connect_timeout: client_config.connect_timeout
+            connect_timeout: client_config.connect_timeout,
+            callback_spawner
         };
 
         client_impl.reconnect_options.normalize();
@@ -743,7 +621,7 @@ impl Mqtt5ClientImpl {
         debug!("Broadcasting client event: {}", *event);
 
         for listener in self.listeners.values() {
-            spawn_event_callback(event.clone(), listener.clone());
+            (self.callback_spawner)(event.clone(), listener.clone());
         }
     }
 
@@ -1202,7 +1080,29 @@ pub mod waiter {
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
-
+/// An async network client that functions as a thin wrapper over the MQTT5 protocol.
+///
+/// A client is always in one of two states:
+/// * Stopped - the client is not connected and will perform no work
+/// * Not Stopped - the client will continually attempt to maintain a connection to the configured broker.
+///
+/// The start() and stop() APIs toggle between these two states.
+///
+/// The client will use configurable exponential backoff with jitter when re-establishing connections.
+///
+/// Regardless of the client's state, you may always safely invoke MQTT operations on it, but
+/// whether or not they are rejected (due to no connection) is a function of client configuration.
+///
+/// There are no mutable functions in the client API, so you can safely share it amongst threads,
+/// runtimes/tasks, etc... by wrapping a newly-constructed client in an Arc.
+///
+/// Submitted operations are placed in a queue where they remain until they reach the head.  At
+/// that point, the operation's packet is assigned a packet id (if appropriate) and encoded and
+/// written to the socket.
+///
+/// Direct client construction is messy due to the different possibilities for TLS, async runtime,
+/// etc...  We encourage you to use the various client builders in this crate, or in other crates,
+/// to simplify this process.
 pub trait AsyncClient {
 
     /// Signals the client that it should attempt to recurrently maintain a connection to
@@ -1239,4 +1139,27 @@ pub trait AsyncClient {
     fn remove_event_listener(&self, listener: ListenerHandle) -> MqttResult<()>;
 }
 
-pub type MqttClient = Arc<dyn AsyncClient>;
+/// An async network client that functions as a thin wrapper over the MQTT5 protocol.
+///
+/// A client is always in one of two states:
+/// * Stopped - the client is not connected and will perform no work
+/// * Not Stopped - the client will continually attempt to maintain a connection to the configured broker.
+///
+/// The start() and stop() APIs toggle between these two states.
+///
+/// The client will use configurable exponential backoff with jitter when re-establishing connections.
+///
+/// Regardless of the client's state, you may always safely invoke MQTT operations on it, but
+/// whether or not they are rejected (due to no connection) is a function of client configuration.
+///
+/// There are no mutable functions in the client API, so you can safely share it amongst threads,
+/// runtimes/tasks, etc... by wrapping a newly-constructed client in an Arc.
+///
+/// Submitted operations are placed in a queue where they remain until they reach the head.  At
+/// that point, the operation's packet is assigned a packet id (if appropriate) and encoded and
+/// written to the socket.
+///
+/// Direct client construction is messy due to the different possibilities for TLS, async runtime,
+/// etc...  We encourage you to use the various client builders in this crate, or in other crates,
+/// to simplify this process.
+pub type AsyncMqttClient = Arc<dyn AsyncClient + Send + Sync>;

--- a/gneiss-mqtt/src/config.rs
+++ b/gneiss-mqtt/src/config.rs
@@ -18,13 +18,11 @@ use std::fs::File;
 use std::io::Read;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::time::Duration;
-use std::future::Future;
-use std::pin::Pin;
 
 #[cfg(feature="websockets")]
-use std::str::FromStr;
-#[cfg(feature="websockets")]
 use http::{Uri, Version};
+#[cfg(feature="websockets")]
+use std::{future::Future, pin::Pin, str::FromStr};
 #[cfg(feature="websockets")]
 use tungstenite::{client::*, handshake::client::generate_key};
 

--- a/gneiss-mqtt/src/config.rs
+++ b/gneiss-mqtt/src/config.rs
@@ -10,7 +10,6 @@ Module containing types for configuring an MQTT client.
 use crate::alias::{OutboundAliasResolverFactoryFn};
 use crate::error::*;
 use crate::client::*;
-use crate::features::gneiss_tokio::{TokioClientOptions};
 use crate::mqtt::*;
 
 use log::*;
@@ -19,33 +18,27 @@ use std::fs::File;
 use std::io::Read;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::time::Duration;
-use tokio::net::TcpStream;
-use tokio::runtime::Handle;
 use std::future::Future;
 use std::pin::Pin;
-use tokio::io::{AsyncRead, AsyncWrite};
 
 #[cfg(feature="websockets")]
 use std::str::FromStr;
 #[cfg(feature="websockets")]
 use http::{Uri, Version};
 #[cfg(feature="websockets")]
-use tungstenite::Message;
-#[cfg(feature="websockets")]
-use tokio_tungstenite::{client_async, WebSocketStream};
-#[cfg(feature="websockets")]
-use stream_ws::{tungstenite::WsMessageHandler, WsMessageHandle, WsByteStream};
-#[cfg(feature="websockets")]
 use tungstenite::{client::*, handshake::client::generate_key};
+
 #[cfg(feature="tokio")]
 use crate::features::gneiss_tokio::*;
+#[cfg(feature="tokio")]
+use tokio::runtime::Handle;
 
 /// Configuration options related to establishing connections through HTTP proxies
 #[derive(Default, Clone)]
 pub struct HttpProxyOptions {
-    endpoint: String,
-    port: u16,
-    tls_options: Option<TlsOptions>
+    pub(crate) endpoint: String,
+    pub(crate) port: u16,
+    pub(crate) tls_options: Option<TlsOptions>
 }
 
 /// Builder type for constructing HTTP-proxy-related configuration.
@@ -755,7 +748,7 @@ pub struct GenericClientBuilder {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-enum TlsConfiguration {
+pub(crate) enum TlsConfiguration {
     None,
     #[cfg(feature = "rustls")]
     Rustls,
@@ -852,7 +845,8 @@ impl GenericClientBuilder {
 
     /// Builds a new MQTT client according to all the configuration options given to the builder.
     /// Does not consume self; can be called multiple times
-    pub fn build(&self, runtime: &Handle) -> MqttResult<AsyncMqttClient> {
+    #[cfg(feature="tokio")]
+    pub fn build_tokio(&self, runtime: &Handle) -> MqttResult<AsyncGneissClient> {
         let tls_impl = self.get_tls_impl();
         if tls_impl == TlsConfiguration::Mixed {
             return Err(MqttError::new_tls_error("Cannot mix two different tls implementations in one client"));
@@ -889,7 +883,7 @@ impl GenericClientBuilder {
 }
 
 #[derive(Clone)]
-struct Endpoint {
+pub(crate) struct Endpoint {
     pub(crate) endpoint: String,
     pub(crate) port: u16,
 }
@@ -903,25 +897,13 @@ impl Endpoint {
     }
 }
 
-fn make_addr(endpoint: &str, port: u16) -> std::io::Result<SocketAddr> {
+pub(crate) fn make_addr(endpoint: &str, port: u16) -> std::io::Result<SocketAddr> {
     let mut to_socket_addrs = (endpoint.to_string(), port).to_socket_addrs()?;
 
     Ok(to_socket_addrs.next().unwrap())
 }
 
-#[allow(clippy::too_many_arguments)]
-fn make_direct_client(tls_impl: TlsConfiguration, endpoint: String, port: u16, _tls_options: Option<TlsOptions>, client_options: MqttClientOptions, connect_options: ConnectOptions, http_proxy_options: Option<HttpProxyOptions>, runtime: &Handle) -> MqttResult<AsyncMqttClient> {
-    match tls_impl {
-        TlsConfiguration::None => { make_direct_client_no_tls(endpoint, port, client_options, connect_options, http_proxy_options, runtime) }
-        #[cfg(feature = "rustls")]
-        TlsConfiguration::Rustls => { make_direct_client_rustls(endpoint, port, _tls_options, client_options, connect_options, http_proxy_options, runtime) }
-        #[cfg(feature = "native-tls")]
-        TlsConfiguration::Nativetls => { make_direct_client_native_tls(endpoint, port, _tls_options, client_options, connect_options, http_proxy_options, runtime) }
-        _ => { panic!("Illegal state"); }
-    }
-}
-
-fn compute_endpoints(endpoint: String, port: u16, http_proxy_options: &Option<HttpProxyOptions>) -> (Endpoint, Option<Endpoint>) {
+pub(crate) fn compute_endpoints(endpoint: String, port: u16, http_proxy_options: &Option<HttpProxyOptions>) -> (Endpoint, Option<Endpoint>) {
     let broker_endpoint = Endpoint::new(endpoint.as_str(), port);
     let proxy_endpoint = http_proxy_options.as_ref().map(|val| { Endpoint::new( val.endpoint.as_str(), val.port )});
     info!("compute_endpoints - broker address - {}:{}", broker_endpoint.endpoint, broker_endpoint.port);
@@ -936,399 +918,9 @@ fn compute_endpoints(endpoint: String, port: u16, http_proxy_options: &Option<Ht
     }
 }
 
-fn make_direct_client_no_tls(endpoint: String, port: u16, client_options: MqttClientOptions, connect_options: ConnectOptions, http_proxy_options: Option<HttpProxyOptions>, runtime: &Handle) -> MqttResult<AsyncMqttClient> {
-    info!("make_direct_client_no_tls - creating async connection establishment closure");
-    let (stream_endpoint, http_connect_endpoint) = compute_endpoints(endpoint, port, &http_proxy_options);
-
-    if http_connect_endpoint.is_some() {
-        let tokio_options = TokioClientOptions {
-            connection_factory: Box::new(move || {
-                let http_connect_endpoint = http_connect_endpoint.clone().unwrap();
-                let tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                Box::pin(apply_proxy_connect_to_stream(tcp_stream, http_connect_endpoint.clone()))
-            }),
-        };
-
-        info!("make_direct_client_no_tls - plaintext-to-proxy -> plaintext-to-broker");
-        Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-    } else {
-        let tokio_options = TokioClientOptions {
-            connection_factory: Box::new(move || {
-                Box::pin(make_leaf_stream(stream_endpoint.clone()))
-            }),
-        };
-
-        info!("make_direct_client_no_tls - plaintext-to-broker");
-        Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-    }
-}
-
-#[cfg(feature = "rustls")]
-fn make_direct_client_rustls(endpoint: String, port: u16, tls_options: Option<TlsOptions>, client_options: MqttClientOptions, connect_options: ConnectOptions, http_proxy_options: Option<HttpProxyOptions>, runtime: &Handle) -> MqttResult<AsyncMqttClient> {
-    info!("make_direct_client_rustls - creating async connection establishment closure");
-
-    let (stream_endpoint, http_connect_endpoint) = compute_endpoints(endpoint.clone(), port, &http_proxy_options);
-
-    if let Some(tls_options) = tls_options {
-        if let Some(http_proxy_options) = http_proxy_options {
-            if let Some(proxy_tls_options) = http_proxy_options.tls_options {
-                let tokio_options = TokioClientOptions {
-                    connection_factory: Box::new(move || {
-                        let http_connect_endpoint = http_connect_endpoint.clone().unwrap();
-                        let proxy_tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                        let proxy_tls_stream = Box::pin(wrap_stream_with_tls_rustls(proxy_tcp_stream, stream_endpoint.endpoint.clone(), proxy_tls_options.clone()));
-                        let connect_stream = Box::pin(apply_proxy_connect_to_stream(proxy_tls_stream, http_connect_endpoint.clone()));
-                        Box::pin(wrap_stream_with_tls_rustls(connect_stream, http_connect_endpoint.endpoint.clone(), tls_options.clone()))
-                    }),
-                };
-
-                info!("make_direct_client_rustls - tls-to-proxy -> tls-to-broker");
-                Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-            } else {
-                let tokio_options = TokioClientOptions {
-                    connection_factory: Box::new(move || {
-                        let http_connect_endpoint = http_connect_endpoint.clone().unwrap();
-                        let proxy_tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                        let connect_stream = Box::pin(apply_proxy_connect_to_stream(proxy_tcp_stream, http_connect_endpoint.clone()));
-                        Box::pin(wrap_stream_with_tls_rustls(connect_stream, http_connect_endpoint.endpoint.clone(), tls_options.clone()))
-                    }),
-                };
-
-                info!("make_direct_client_rustls - plaintext-to-proxy -> tls-to-broker");
-                Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-            }
-        } else {
-            let tokio_options = TokioClientOptions {
-                connection_factory: Box::new(move || {
-                    let tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                    Box::pin(wrap_stream_with_tls_rustls(tcp_stream, endpoint.clone(), tls_options.clone()))
-                }),
-            };
-
-            info!("make_direct_client_rustls - tls-to-broker");
-            Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-        }
-    } else if let Some(http_proxy_options) = http_proxy_options {
-        if let Some(proxy_tls_options) = http_proxy_options.tls_options {
-            let tokio_options = TokioClientOptions {
-                connection_factory: Box::new(move || {
-                    let http_connect_endpoint = http_connect_endpoint.clone().unwrap();
-                    let proxy_tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                    let proxy_tls_stream = Box::pin(wrap_stream_with_tls_rustls(proxy_tcp_stream, stream_endpoint.endpoint.clone(), proxy_tls_options.clone()));
-                    Box::pin(apply_proxy_connect_to_stream(proxy_tls_stream, http_connect_endpoint.clone()))
-                }),
-            };
-
-            info!("make_direct_client_rustls - tls-to-proxy -> plaintext-to-broker");
-            Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-        } else {
-            panic!("Tls direct client creation invoked without tls configuration")
-        }
-    } else {
-        panic!("Tls direct client creation invoked without tls configuration")
-    }
-}
-
-#[cfg(feature = "native-tls")]
-fn make_direct_client_native_tls(endpoint: String, port: u16, tls_options: Option<TlsOptions>, client_options: MqttClientOptions, connect_options: ConnectOptions, http_proxy_options: Option<HttpProxyOptions>, runtime: &Handle) -> MqttResult<AsyncMqttClient> {
-    info!("make_direct_client_native_tls - creating async connection establishment closure");
-
-    let (stream_endpoint, http_connect_endpoint) = compute_endpoints(endpoint.clone(), port, &http_proxy_options);
-
-    if let Some(tls_options) = tls_options {
-        if let Some(http_proxy_options) = http_proxy_options {
-            if let Some(proxy_tls_options) = http_proxy_options.tls_options {
-                let tokio_options = TokioClientOptions {
-                    connection_factory: Box::new(move || {
-                        let http_connect_endpoint = http_connect_endpoint.clone().unwrap();
-                        let proxy_tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                        let proxy_tls_stream = Box::pin(wrap_stream_with_tls_native_tls(proxy_tcp_stream, stream_endpoint.endpoint.clone(), proxy_tls_options.clone()));
-                        let connect_stream = Box::pin(apply_proxy_connect_to_stream(proxy_tls_stream, http_connect_endpoint.clone()));
-                        Box::pin(wrap_stream_with_tls_native_tls(connect_stream, http_connect_endpoint.endpoint.clone(), tls_options.clone()))
-                    }),
-                };
-
-                info!("make_direct_client_native_tls - tls-to-proxy -> tls-to-broker");
-                Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-            } else {
-                let tokio_options = TokioClientOptions {
-                    connection_factory: Box::new(move || {
-                        let http_connect_endpoint = http_connect_endpoint.clone().unwrap();
-                        let proxy_tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                        let connect_stream = Box::pin(apply_proxy_connect_to_stream(proxy_tcp_stream, http_connect_endpoint.clone()));
-                        Box::pin(wrap_stream_with_tls_native_tls(connect_stream, http_connect_endpoint.endpoint.clone(), tls_options.clone()))
-                    }),
-                };
-
-                info!("make_direct_client_native_tls - plaintext-to-proxy -> tls-to-broker");
-                Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-            }
-        } else {
-            let tokio_options = TokioClientOptions {
-                connection_factory: Box::new(move || {
-                    let tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                    Box::pin(wrap_stream_with_tls_native_tls(tcp_stream, endpoint.clone(), tls_options.clone()))
-                }),
-            };
-
-            info!("make_direct_client_native_tls - tls-to-broker");
-            Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-        }
-    } else if let Some(http_proxy_options) = http_proxy_options {
-        if let Some(proxy_tls_options) = http_proxy_options.tls_options {
-            let tokio_options = TokioClientOptions {
-                connection_factory: Box::new(move || {
-                    let http_connect_endpoint = http_connect_endpoint.clone().unwrap();
-                    let proxy_tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                    let proxy_tls_stream = Box::pin(wrap_stream_with_tls_native_tls(proxy_tcp_stream, stream_endpoint.endpoint.clone(), proxy_tls_options.clone()));
-                    Box::pin(apply_proxy_connect_to_stream(proxy_tls_stream, http_connect_endpoint.clone()))
-                }),
-            };
-
-            info!("make_direct_client_native_tls - tls-to-proxy -> plaintext-to-broker");
-            Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-        } else {
-            panic!("Tls direct client creation invoked without tls configuration")
-        }
-    } else {
-        panic!("Tls direct client creation invoked without tls configuration")
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
 #[cfg(feature="websockets")]
-fn make_websocket_client(tls_impl: TlsConfiguration, endpoint: String, port: u16, websocket_options: WebsocketOptions, _tls_options: Option<TlsOptions>, client_options: MqttClientOptions, connect_options: ConnectOptions, http_proxy_options: Option<HttpProxyOptions>, runtime: &Handle) -> MqttResult<AsyncMqttClient> {
-    match tls_impl {
-        TlsConfiguration::None => { make_websocket_client_no_tls(endpoint, port, websocket_options, client_options, connect_options, http_proxy_options, runtime) }
-        #[cfg(feature = "rustls")]
-        TlsConfiguration::Rustls => { make_websocket_client_rustls(endpoint, port, websocket_options, _tls_options, client_options, connect_options, http_proxy_options, runtime) }
-        #[cfg(feature = "native-tls")]
-        TlsConfiguration::Nativetls => { make_websocket_client_native_tls(endpoint, port, websocket_options, _tls_options, client_options, connect_options, http_proxy_options, runtime) }
-        _ => { panic!("Illegal state"); }
-    }
-}
-
-#[cfg(feature="websockets")]
-fn make_websocket_client_no_tls(endpoint: String, port: u16, websocket_options: WebsocketOptions, client_options: MqttClientOptions, connect_options: ConnectOptions, http_proxy_options: Option<HttpProxyOptions>, runtime: &Handle) -> MqttResult<AsyncMqttClient> {
-    info!("make_websocket_client_no_tls - creating async connection establishment closure");
-    let (stream_endpoint, http_connect_endpoint) = compute_endpoints(endpoint, port, &http_proxy_options);
-
-    if http_connect_endpoint.is_some() {
-        let tokio_options = TokioClientOptions {
-            connection_factory: Box::new(move || {
-                let http_connect_endpoint = http_connect_endpoint.clone().unwrap();
-                let proxy_tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                let connect_stream = Box::pin(apply_proxy_connect_to_stream(proxy_tcp_stream, http_connect_endpoint.clone()));
-                Box::pin(wrap_stream_with_websockets(connect_stream, http_connect_endpoint.endpoint.clone(), "ws", websocket_options.clone()))
-            }),
-        };
-
-        info!("create_websocket_client_plaintext_to_proxy_plaintext_to_broker");
-        Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-    } else {
-        let tokio_options = TokioClientOptions {
-            connection_factory: Box::new(move || {
-                let tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                Box::pin(wrap_stream_with_websockets(tcp_stream, stream_endpoint.endpoint.clone(), "ws", websocket_options.clone()))
-            }),
-        };
-
-        info!("create_websocket_client_plaintext_to_broker");
-        Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-#[cfg(all(feature = "rustls", feature = "websockets"))]
-fn make_websocket_client_rustls(endpoint: String, port: u16, websocket_options: WebsocketOptions, tls_options: Option<TlsOptions>, client_options: MqttClientOptions, connect_options: ConnectOptions, http_proxy_options: Option<HttpProxyOptions>, runtime: &Handle) -> MqttResult<AsyncMqttClient> {
-    info!("make_websocket_client_rustls - creating async connection establishment closure");
-    let (stream_endpoint, http_connect_endpoint) = compute_endpoints(endpoint.clone(), port, &http_proxy_options);
-
-    if let Some(tls_options) = tls_options {
-        if let Some(http_proxy_options) = http_proxy_options {
-            if let Some(proxy_tls_options) = http_proxy_options.tls_options {
-                let tokio_options = TokioClientOptions {
-                    connection_factory: Box::new(move || {
-                        let http_connect_endpoint = http_connect_endpoint.clone().unwrap();
-                        let proxy_tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                        let proxy_tls_stream = Box::pin(wrap_stream_with_tls_rustls(proxy_tcp_stream, stream_endpoint.endpoint.clone(), proxy_tls_options.clone()));
-                        let connect_stream = Box::pin(apply_proxy_connect_to_stream(proxy_tls_stream, http_connect_endpoint.clone()));
-                        let tls_stream = Box::pin(wrap_stream_with_tls_rustls(connect_stream, http_connect_endpoint.endpoint.clone(), tls_options.clone()));
-                        Box::pin(wrap_stream_with_websockets(tls_stream, http_connect_endpoint.endpoint.clone(), "wss", websocket_options.clone()))
-                    }),
-                };
-
-                info!("make_websocket_client_rustls - tls-to-proxy -> tls-to-broker");
-                Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-            } else {
-                let tokio_options = TokioClientOptions {
-                    connection_factory: Box::new(move || {
-                        let http_connect_endpoint = http_connect_endpoint.clone().unwrap();
-                        let proxy_tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                        let connect_stream = Box::pin(apply_proxy_connect_to_stream(proxy_tcp_stream, http_connect_endpoint.clone()));
-                        let tls_stream = Box::pin(wrap_stream_with_tls_rustls(connect_stream, http_connect_endpoint.endpoint.clone(), tls_options.clone()));
-                        Box::pin(wrap_stream_with_websockets(tls_stream, http_connect_endpoint.endpoint.clone(), "wss", websocket_options.clone()))
-                    }),
-                };
-
-                info!("make_websocket_client_rustls - plaintext-to-proxy -> tls-to-broker");
-                Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-            }
-        } else {
-            let tokio_options = TokioClientOptions {
-                connection_factory: Box::new(move || {
-                    let tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                    let tls_stream = Box::pin(wrap_stream_with_tls_rustls(tcp_stream, stream_endpoint.endpoint.clone(), tls_options.clone()));
-                    Box::pin(wrap_stream_with_websockets(tls_stream, stream_endpoint.endpoint.clone(), "wss", websocket_options.clone()))
-                }),
-            };
-
-            info!("make_websocket_client_rustls - tls-to-broker");
-            Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-        }
-    } else if let Some(http_proxy_options) = http_proxy_options {
-        if let Some(proxy_tls_options) = http_proxy_options.tls_options {
-            let tokio_options = TokioClientOptions {
-                connection_factory: Box::new(move || {
-                    let http_connect_endpoint = http_connect_endpoint.clone().unwrap();
-                    let proxy_tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                    let proxy_tls_stream = Box::pin(wrap_stream_with_tls_rustls(proxy_tcp_stream, stream_endpoint.endpoint.clone(), proxy_tls_options.clone()));
-                    let connect_stream = Box::pin(apply_proxy_connect_to_stream(proxy_tls_stream, http_connect_endpoint.clone()));
-                    Box::pin(wrap_stream_with_websockets(connect_stream, http_connect_endpoint.endpoint.clone(), "ws", websocket_options.clone()))
-                }),
-            };
-
-            info!("make_websocket_client_rustls - tls-to-proxy -> plaintext-to-broker");
-            Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-        } else {
-            panic!("Tls websocket client creation invoked without tls configuration")
-        }
-    } else {
-        panic!("Tls websocket client creation invoked without tls configuration")
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-#[cfg(all(feature = "native-tls", feature = "websockets"))]
-fn make_websocket_client_native_tls(endpoint: String, port: u16, websocket_options: WebsocketOptions, tls_options: Option<TlsOptions>, client_options: MqttClientOptions, connect_options: ConnectOptions, http_proxy_options: Option<HttpProxyOptions>, runtime: &Handle) -> MqttResult<AsyncMqttClient> {
-    info!("make_websocket_client_native_tls - creating async connection establishment closure");
-    let (stream_endpoint, http_connect_endpoint) = compute_endpoints(endpoint.clone(), port, &http_proxy_options);
-
-    if let Some(tls_options) = tls_options {
-        if let Some(http_proxy_options) = http_proxy_options {
-            if let Some(proxy_tls_options) = http_proxy_options.tls_options {
-                let tokio_options = TokioClientOptions {
-                    connection_factory: Box::new(move || {
-                        let http_connect_endpoint = http_connect_endpoint.clone().unwrap();
-                        let proxy_tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                        let proxy_tls_stream = Box::pin(wrap_stream_with_tls_native_tls(proxy_tcp_stream, stream_endpoint.endpoint.clone(), proxy_tls_options.clone()));
-                        let connect_stream = Box::pin(apply_proxy_connect_to_stream(proxy_tls_stream, http_connect_endpoint.clone()));
-                        let tls_stream = Box::pin(wrap_stream_with_tls_native_tls(connect_stream, http_connect_endpoint.endpoint.clone(), tls_options.clone()));
-                        Box::pin(wrap_stream_with_websockets(tls_stream, http_connect_endpoint.endpoint.clone(), "wss", websocket_options.clone()))
-                    }),
-                };
-
-                info!("make_websocket_client_native_tls - tls-to-proxy -> tls-to-broker");
-                Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-            } else {
-                let tokio_options = TokioClientOptions {
-                    connection_factory: Box::new(move || {
-                        let http_connect_endpoint = http_connect_endpoint.clone().unwrap();
-                        let proxy_tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                        let connect_stream = Box::pin(apply_proxy_connect_to_stream(proxy_tcp_stream, http_connect_endpoint.clone()));
-                        let tls_stream = Box::pin(wrap_stream_with_tls_native_tls(connect_stream, http_connect_endpoint.endpoint.clone(), tls_options.clone()));
-                        Box::pin(wrap_stream_with_websockets(tls_stream, http_connect_endpoint.endpoint.clone(), "wss", websocket_options.clone()))
-                    }),
-                };
-
-                info!("make_websocket_client_native_tls - plaintext-to-proxy -> tls-to-broker");
-                Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-            }
-        } else {
-            let tokio_options = TokioClientOptions {
-                connection_factory: Box::new(move || {
-                    let tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                    let tls_stream = Box::pin(wrap_stream_with_tls_native_tls(tcp_stream, stream_endpoint.endpoint.clone(), tls_options.clone()));
-                    Box::pin(wrap_stream_with_websockets(tls_stream, stream_endpoint.endpoint.clone(), "wss", websocket_options.clone()))
-                }),
-            };
-
-            info!("make_websocket_client_native_tls - tls-to-broker");
-            Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-        }
-    } else if let Some(http_proxy_options) = http_proxy_options {
-        if let Some(proxy_tls_options) = http_proxy_options.tls_options {
-            let tokio_options = TokioClientOptions {
-                connection_factory: Box::new(move || {
-                    let http_connect_endpoint = http_connect_endpoint.clone().unwrap();
-                    let proxy_tcp_stream = Box::pin(make_leaf_stream(stream_endpoint.clone()));
-                    let proxy_tls_stream = Box::pin(wrap_stream_with_tls_native_tls(proxy_tcp_stream, stream_endpoint.endpoint.clone(), proxy_tls_options.clone()));
-                    let connect_stream = Box::pin(apply_proxy_connect_to_stream(proxy_tls_stream, http_connect_endpoint.clone()));
-                    Box::pin(wrap_stream_with_websockets(connect_stream, http_connect_endpoint.endpoint.clone(), "ws", websocket_options.clone()))
-                }),
-            };
-
-            info!("make_websocket_client_native_tls - tls-to-proxy -> plaintext-to-broker");
-            Ok(new_with_tokio(client_options, connect_options, tokio_options, runtime))
-        } else {
-            panic!("Tls websocket client creation invoked without tls configuration")
-        }
-    } else {
-        panic!("Tls websocket client creation invoked without tls configuration")
-    }
-}
-
-async fn make_leaf_stream(endpoint: Endpoint) -> MqttResult<TcpStream> {
-    let addr = make_addr(endpoint.endpoint.as_str(), endpoint.port)?;
-    debug!("make_leaf_stream - opening TCP stream");
-    let stream = TcpStream::connect(&addr).await?;
-    debug!("make_leaf_stream - TCP stream successfully established");
-
-    Ok(stream)
-}
-
-#[cfg(feature = "rustls")]
-async fn wrap_stream_with_tls_rustls<S>(stream : Pin<Box<impl Future<Output=MqttResult<S>>+Sized>>, endpoint: String, tls_options: TlsOptions) -> MqttResult<tokio_rustls::client::TlsStream<S>> where S : AsyncRead + AsyncWrite + Unpin {
-    let domain = rustls_pki_types::ServerName::try_from(endpoint)?
-        .to_owned();
-
-    let connector =
-        match tls_options.options {
-            TlsData::Rustls(_, config) => { tokio_rustls::TlsConnector::from(config.clone()) }
-            _ => { panic!("Rustls stream wrapper invoked without Rustls configuration"); }
-        };
-
-    debug!("wrap_stream_with_tls_rustls - performing tls handshake");
-    let inner_stream= stream.await?;
-    let tls_stream = connector.connect(domain, inner_stream).await?;
-    debug!("wrap_stream_with_tls_rustls - tls handshake successfully completed");
-
-    Ok(tls_stream)
-}
-
-#[cfg(feature = "native-tls")]
-async fn wrap_stream_with_tls_native_tls<S>(stream : Pin<Box<impl Future<Output=MqttResult<S>>+Sized>>, endpoint: String, tls_options: TlsOptions) -> MqttResult<tokio_native_tls::TlsStream<S>> where S : AsyncRead + AsyncWrite + Unpin {
-
-    let connector =
-        match tls_options.options {
-            TlsData::NativeTls(_, ntls_builder) => {
-                let cx = ntls_builder.build()?;
-                tokio_native_tls::TlsConnector::from(cx)
-            }
-            _ => { panic!("Native-tls stream wrapper invoked without Native-tls configuration"); }
-        };
-
-    debug!("wrap_stream_with_tls_native_tls - performing tls handshake");
-    let inner_stream = stream.await?;
-    let tls_stream = connector.connect(endpoint.as_str(), inner_stream).await?;
-    debug!("wrap_stream_with_tls_native_tls - tls handshake successfully completed");
-
-    Ok(tls_stream)
-}
-
-#[cfg(feature="websockets")]
-struct HandshakeRequest {
-    handshake_builder: http::request::Builder,
+pub(crate) struct HandshakeRequest {
+    pub(crate) handshake_builder: http::request::Builder,
 }
 
 #[cfg(feature="websockets")]
@@ -1340,7 +932,7 @@ impl IntoClientRequest for HandshakeRequest {
 }
 
 #[cfg(feature="websockets")]
-fn create_default_websocket_handshake_request(uri: String) -> MqttResult<http::request::Builder> {
+pub(crate) fn create_default_websocket_handshake_request(uri: String) -> MqttResult<http::request::Builder> {
     let uri = Uri::from_str(uri.as_str()).unwrap();
 
     Ok(http::Request::builder()
@@ -1354,84 +946,3 @@ fn create_default_websocket_handshake_request(uri: String) -> MqttResult<http::r
         .header("Host", uri.host().unwrap()))
 }
 
-#[cfg(feature="websockets")]
-async fn wrap_stream_with_websockets<S>(stream : Pin<Box<impl Future<Output=MqttResult<S>>+Sized>>, endpoint: String, scheme: &str, websocket_options: WebsocketOptions) -> MqttResult<WsByteStream<WebSocketStream<S>, Message, tungstenite::Error, WsMessageHandler>> where S : AsyncRead + AsyncWrite + Unpin {
-
-    let uri = format!("{}://{}/mqtt", scheme, endpoint); // scheme needs to be present but value irrelevant
-    let handshake_builder = create_default_websocket_handshake_request(uri)?;
-
-    debug!("wrap_stream_with_websockets - performing websocket upgrade request transform");
-    let transformed_handshake_builder =
-        if let Some(transform) = &*websocket_options.handshake_transform {
-            transform(handshake_builder).await?
-        } else {
-            handshake_builder
-        };
-    debug!("wrap_stream_with_websockets - successfully transformed websocket upgrade request");
-
-    debug!("wrap_stream_with_websockets - upgrading stream to websockets");
-    let inner_stream= stream.await?;
-    let (message_stream, _) = client_async( HandshakeRequest { handshake_builder: transformed_handshake_builder }, inner_stream).await?;
-    let byte_stream = WsMessageHandler::wrap_stream(message_stream);
-    debug!("wrap_stream_with_websockets - successfully upgraded stream to websockets");
-
-    Ok(byte_stream)
-}
-
-fn build_connect_request(http_connect_endpoint: &Endpoint) -> Vec<u8> {
-    let request_as_string = format!("CONNECT {}:{} HTTP/1.1\r\nHost: {}:{}\r\nConnection: keep-alive\r\n\r\n", http_connect_endpoint.endpoint, http_connect_endpoint.port, http_connect_endpoint.endpoint, http_connect_endpoint.port);
-
-    return request_as_string.as_bytes().to_vec();
-}
-
-use tokio::io::AsyncWriteExt;
-use tokio::io::AsyncReadExt;
-
-async fn apply_proxy_connect_to_stream<S>(stream : Pin<Box<impl Future<Output=MqttResult<S>>+Sized>>, http_connect_endpoint: Endpoint) -> MqttResult<S> where S : AsyncRead + AsyncWrite + Unpin {
-    let mut inner_stream = stream.await?;
-
-    debug!("apply_proxy_connect_to_stream - writing CONNECT request to connection stream");
-    let request_bytes = build_connect_request(&http_connect_endpoint);
-    inner_stream.write_all(request_bytes.as_slice()).await?;
-    debug!("apply_proxy_connect_to_stream - successfully wrote CONNECT request to stream");
-
-    let mut inbound_data: [u8; 4096] = [0; 4096];
-    let mut response_bytes = Vec::new();
-
-    loop {
-        let bytes_read = inner_stream.read(&mut inbound_data).await?;
-        if bytes_read == 0 {
-            info!("apply_proxy_connect_to_stream - proxy connect stream closed with zero byte read");
-            return Err(MqttError::new_connection_establishment_failure("proxy connect stream closed"));
-        }
-
-        response_bytes.extend_from_slice(&inbound_data[..bytes_read]);
-
-        let mut headers = [httparse::EMPTY_HEADER; 32];
-        let mut response = httparse::Response::new(&mut headers);
-
-        let parse_result = response.parse(response_bytes.as_slice());
-        match parse_result {
-            Err(e) => {
-                error!("apply_proxy_connect_to_stream - failed to parse proxy response to CONNECT request: {:?}", e);
-                return Err(MqttError::new_connection_establishment_failure(e));
-            }
-            Ok(httparse::Status::Complete(bytes_parsed)) => {
-                if bytes_parsed < response_bytes.len() {
-                    error!("apply_proxy_connect_to_stream - stream incoming data contains more data than the CONNECT response");
-                    return Err(MqttError::new_connection_establishment_failure("proxy connect response too long"));
-                }
-
-                if let Some(response_code) = response.code {
-                    if (200..300).contains(&response_code) {
-                        return Ok(inner_stream);
-                    }
-                }
-
-                error!("apply_proxy_connect_to_stream - CONNECT request was failed, with http code: {:?}", response.code);
-                return Err(MqttError::new_connection_establishment_failure("proxy connect request unsuccessful"));
-            }
-            Ok(httparse::Status::Partial) => {}
-        }
-    }
-}

--- a/gneiss-mqtt/src/config.rs
+++ b/gneiss-mqtt/src/config.rs
@@ -19,11 +19,11 @@ use std::io::Read;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::time::Duration;
 
-#[cfg(feature="websockets")]
+#[cfg(feature="tokio-websockets")]
 use http::{Uri, Version};
-#[cfg(feature="websockets")]
+#[cfg(feature="tokio-websockets")]
 use std::{future::Future, pin::Pin, str::FromStr};
-#[cfg(feature="websockets")]
+#[cfg(feature="tokio-websockets")]
 use tungstenite::{client::*, handshake::client::generate_key};
 
 #[cfg(feature="tokio")]
@@ -71,28 +71,28 @@ impl HttpProxyOptionsBuilder {
 }
 
 /// Return type for a websocket handshake transformation function
-#[cfg(feature="websockets")]
+#[cfg(feature="tokio-websockets")]
 pub type WebsocketHandshakeTransformReturnType = Pin<Box<dyn Future<Output = MqttResult<http::request::Builder>> + Send >>;
 
 /// Async websocket handshake transformation function type
-#[cfg(feature="websockets")]
+#[cfg(feature="tokio-websockets")]
 pub type WebsocketHandshakeTransform = Box<dyn Fn(http::request::Builder) -> WebsocketHandshakeTransformReturnType + Send + Sync>;
 
 /// Configuration options related to establishing an MQTT over websockets
 #[derive(Default, Clone)]
-#[cfg(feature="websockets")]
+#[cfg(feature="tokio-websockets")]
 pub struct WebsocketOptions {
     pub(crate) handshake_transform: std::sync::Arc<Option<WebsocketHandshakeTransform>>
 }
 
 /// Builder type for constructing Websockets-related configuration.
 #[derive(Default)]
-#[cfg(feature="websockets")]
+#[cfg(feature="tokio-websockets")]
 pub struct WebsocketOptionsBuilder {
     options : WebsocketOptions
 }
 
-#[cfg(feature="websockets")]
+#[cfg(feature="tokio-websockets")]
 impl WebsocketOptionsBuilder {
 
     /// Creates a new builder object with default options.
@@ -128,10 +128,10 @@ pub(crate) enum TlsData {
     #[allow(dead_code)]
     Invalid,
 
-    #[cfg(feature = "rustls")]
+    #[cfg(feature = "tokio-rustls")]
     Rustls(TlsMode, std::sync::Arc<rustls::ClientConfig>),
 
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "tokio-native-tls")]
     NativeTls(TlsMode, std::sync::Arc<native_tls::TlsConnectorBuilder>)
 }
 
@@ -740,7 +740,7 @@ pub struct GenericClientBuilder {
     tls_options: Option<TlsOptions>,
     connect_options: Option<ConnectOptions>,
     client_options: Option<MqttClientOptions>,
-    #[cfg(feature="websockets")]
+    #[cfg(feature="tokio-websockets")]
     websocket_options: Option<WebsocketOptions>,
     http_proxy_options: Option<HttpProxyOptions>
 }
@@ -748,9 +748,9 @@ pub struct GenericClientBuilder {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum TlsConfiguration {
     None,
-    #[cfg(feature = "rustls")]
+    #[cfg(feature = "tokio-rustls")]
     Rustls,
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "tokio-native-tls")]
     Nativetls,
     Mixed
 }
@@ -759,9 +759,9 @@ fn get_tls_impl_from_options(tls_options: Option<&TlsOptions>) -> TlsConfigurati
     if let Some(tls_opts) = tls_options {
         return
             match &tls_opts.options {
-                #[cfg(feature = "rustls")]
+                #[cfg(feature = "tokio-rustls")]
                 TlsData::Rustls(_, _) => { TlsConfiguration::Rustls }
-                #[cfg(feature = "native-tls")]
+                #[cfg(feature = "tokio-native-tls")]
                 TlsData::NativeTls(_, _) => { TlsConfiguration::Nativetls }
                 _ => { TlsConfiguration::None }
             };
@@ -780,7 +780,7 @@ impl GenericClientBuilder {
             tls_options: None,
             connect_options: None,
             client_options: None,
-            #[cfg(feature="websockets")]
+            #[cfg(feature="tokio-websockets")]
             websocket_options: None,
             http_proxy_options: None
         }
@@ -807,7 +807,7 @@ impl GenericClientBuilder {
     }
 
     /// Configures the client to connect over websockets
-    #[cfg(feature="websockets")]
+    #[cfg(feature="tokio-websockets")]
     pub fn with_websocket_options(&mut self, websocket_options: WebsocketOptions) -> &mut Self {
         self.websocket_options = Some(websocket_options);
         self
@@ -868,7 +868,7 @@ impl GenericClientBuilder {
         let tls_options = self.tls_options.clone();
         let endpoint = self.endpoint.clone();
 
-        #[cfg(feature="websockets")]
+        #[cfg(feature="tokio-websockets")]
         {
             let websocket_options = self.websocket_options.clone();
             if let Some(websocket_options) = websocket_options {
@@ -916,12 +916,12 @@ pub(crate) fn compute_endpoints(endpoint: String, port: u16, http_proxy_options:
     }
 }
 
-#[cfg(feature="websockets")]
+#[cfg(feature="tokio-websockets")]
 pub(crate) struct HandshakeRequest {
     pub(crate) handshake_builder: http::request::Builder,
 }
 
-#[cfg(feature="websockets")]
+#[cfg(feature="tokio-websockets")]
 impl IntoClientRequest for HandshakeRequest {
     fn into_client_request(self) -> tungstenite::Result<tungstenite::handshake::client::Request> {
         let final_request = self.handshake_builder.body(()).unwrap();
@@ -929,7 +929,7 @@ impl IntoClientRequest for HandshakeRequest {
     }
 }
 
-#[cfg(feature="websockets")]
+#[cfg(feature="tokio-websockets")]
 pub(crate) fn create_default_websocket_handshake_request(uri: String) -> MqttResult<http::request::Builder> {
     let uri = Uri::from_str(uri.as_str()).unwrap();
 

--- a/gneiss-mqtt/src/error.rs
+++ b/gneiss-mqtt/src/error.rs
@@ -502,6 +502,32 @@ impl From<tungstenite::error::Error> for MqttError {
     }
 }
 
+#[cfg(feature="tokio")]
+impl From<tokio::sync::oneshot::error::RecvError> for MqttError {
+    fn from(err: tokio::sync::oneshot::error::RecvError) -> Self {
+        MqttError::new_operation_channel_failure(err)
+    }
+}
+
+impl <T> From<std::sync::mpsc::SendError<T>> for MqttError where T : Send + Sync + 'static {
+    fn from(err: std::sync::mpsc::SendError<T>) -> Self {
+        MqttError::new_operation_channel_failure(err)
+    }
+}
+
+impl From<std::sync::mpsc::RecvError> for MqttError {
+    fn from(err: std::sync::mpsc::RecvError) -> Self {
+        MqttError::new_operation_channel_failure(err)
+    }
+}
+
+impl From<std::sync::mpsc::TryRecvError> for MqttError {
+    fn from(err: std::sync::mpsc::TryRecvError) -> Self {
+        MqttError::new_operation_channel_failure(err)
+    }
+}
+
+
 /// Crate-wide result type for functions that can fail
 pub type MqttResult<T> = Result<T, MqttError>;
 

--- a/gneiss-mqtt/src/error.rs
+++ b/gneiss-mqtt/src/error.rs
@@ -474,28 +474,28 @@ impl From<core::str::Utf8Error> for MqttError {
     }
 }
 
-#[cfg(feature = "rustls")]
+#[cfg(feature = "tokio-rustls")]
 impl From<rustls_pki_types::InvalidDnsNameError> for MqttError {
     fn from(err: rustls_pki_types::InvalidDnsNameError) -> Self {
         MqttError::new_connection_establishment_failure(err)
     }
 }
 
-#[cfg(feature = "rustls")]
+#[cfg(feature = "tokio-rustls")]
 impl From<rustls::Error> for MqttError {
     fn from(err: rustls::Error) -> Self {
         MqttError::new_tls_error(err)
     }
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "tokio-native-tls")]
 impl From<native_tls::Error> for MqttError {
     fn from(err: native_tls::Error) -> Self {
         MqttError::new_tls_error(err)
     }
 }
 
-#[cfg(feature="websockets")]
+#[cfg(feature="tokio-websockets")]
 impl From<tungstenite::error::Error> for MqttError {
     fn from(err: tungstenite::error::Error) -> Self {
         MqttError::new_transport_error(err)

--- a/gneiss-mqtt/src/features/gneiss_tokio/longtests.rs
+++ b/gneiss-mqtt/src/features/gneiss_tokio/longtests.rs
@@ -31,7 +31,7 @@ fn is_reconnect_related_event(event: &Arc<ClientEvent>) -> bool {
 type ReconnectEventTestValidatorFn = Box<dyn Fn(&Vec<ClientEventRecord>) -> MqttResult<()> + Send + Sync>;
 
 async fn simple_reconnect_test(builder : GenericClientBuilder, event_count: usize, event_checker: ReconnectEventTestValidatorFn) -> MqttResult<()> {
-    let client = builder.build(&tokio::runtime::Handle::current()).unwrap();
+    let client = builder.build_tokio(&tokio::runtime::Handle::current()).unwrap();
 
     let wait_options = ClientEventWaiterOptions {
         wait_type: ClientEventWaitType::Predicate(Box::new(|event|{ is_reconnect_related_event(event) }))
@@ -179,7 +179,7 @@ fn build_reconnect_reset_test_options() -> ClientTestOptions {
 }
 
 async fn reconnect_backoff_reset_test(builder : GenericClientBuilder, first_event_checker: ReconnectEventTestValidatorFn, second_event_checker_fn: ReconnectEventTestValidatorFn, connection_success_wait_millis: u64) -> MqttResult<()> {
-    let client = builder.build(&tokio::runtime::Handle::current()).unwrap();
+    let client = builder.build_tokio(&tokio::runtime::Handle::current()).unwrap();
 
     let first_wait_options = ClientEventWaiterOptions {
         wait_type: ClientEventWaitType::Predicate(Box::new(|event|{ is_reconnect_related_event(event) }))

--- a/gneiss-mqtt/src/features/gneiss_tokio/longtests.rs
+++ b/gneiss-mqtt/src/features/gneiss_tokio/longtests.rs
@@ -31,7 +31,7 @@ fn is_reconnect_related_event(event: &Arc<ClientEvent>) -> bool {
 type ReconnectEventTestValidatorFn = Box<dyn Fn(&Vec<ClientEventRecord>) -> MqttResult<()> + Send + Sync>;
 
 async fn simple_reconnect_test(builder : GenericClientBuilder, event_count: usize, event_checker: ReconnectEventTestValidatorFn) -> MqttResult<()> {
-    let client = Arc::new(builder.build(&tokio::runtime::Handle::current()).unwrap());
+    let client = builder.build(&tokio::runtime::Handle::current()).unwrap();
 
     let wait_options = ClientEventWaiterOptions {
         wait_type: ClientEventWaitType::Predicate(Box::new(|event|{ is_reconnect_related_event(event) }))
@@ -179,7 +179,7 @@ fn build_reconnect_reset_test_options() -> ClientTestOptions {
 }
 
 async fn reconnect_backoff_reset_test(builder : GenericClientBuilder, first_event_checker: ReconnectEventTestValidatorFn, second_event_checker_fn: ReconnectEventTestValidatorFn, connection_success_wait_millis: u64) -> MqttResult<()> {
-    let client = Arc::new(builder.build(&tokio::runtime::Handle::current()).unwrap());
+    let client = builder.build(&tokio::runtime::Handle::current()).unwrap();
 
     let first_wait_options = ClientEventWaiterOptions {
         wait_type: ClientEventWaitType::Predicate(Box::new(|event|{ is_reconnect_related_event(event) }))

--- a/gneiss-mqtt/src/features/gneiss_tokio/mod.rs
+++ b/gneiss-mqtt/src/features/gneiss_tokio/mod.rs
@@ -26,11 +26,11 @@ use tokio::{runtime, runtime::Handle};
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::time::{sleep};
 
-#[cfg(feature="websockets")]
+#[cfg(feature="tokio-websockets")]
 use stream_ws::{tungstenite::WsMessageHandler, WsMessageHandle, WsByteStream};
-#[cfg(feature="websockets")]
+#[cfg(feature="tokio-websockets")]
 use tokio_tungstenite::{client_async, WebSocketStream};
-#[cfg(feature="websockets")]
+#[cfg(feature="tokio-websockets")]
 use tungstenite::Message;
 
 pub(crate) struct ClientRuntimeState<T> where T : AsyncRead + AsyncWrite + Send + Sync + 'static {
@@ -532,9 +532,9 @@ pub fn new_with_tokio<T>(client_config: MqttClientOptions, connect_config: Conne
 pub(crate) fn make_direct_client(tls_impl: TlsConfiguration, endpoint: String, port: u16, _tls_options: Option<TlsOptions>, client_options: MqttClientOptions, connect_options: ConnectOptions, http_proxy_options: Option<HttpProxyOptions>, runtime: &Handle) -> MqttResult<AsyncGneissClient> {
     match tls_impl {
         TlsConfiguration::None => { make_direct_client_no_tls(endpoint, port, client_options, connect_options, http_proxy_options, runtime) }
-        #[cfg(feature = "rustls")]
+        #[cfg(feature = "tokio-rustls")]
         TlsConfiguration::Rustls => { make_direct_client_rustls(endpoint, port, _tls_options, client_options, connect_options, http_proxy_options, runtime) }
-        #[cfg(feature = "native-tls")]
+        #[cfg(feature = "tokio-native-tls")]
         TlsConfiguration::Nativetls => { make_direct_client_native_tls(endpoint, port, _tls_options, client_options, connect_options, http_proxy_options, runtime) }
         _ => { panic!("Illegal state"); }
     }
@@ -567,7 +567,7 @@ fn make_direct_client_no_tls(endpoint: String, port: u16, client_options: MqttCl
     }
 }
 
-#[cfg(feature = "rustls")]
+#[cfg(feature = "tokio-rustls")]
 fn make_direct_client_rustls(endpoint: String, port: u16, tls_options: Option<TlsOptions>, client_options: MqttClientOptions, connect_options: ConnectOptions, http_proxy_options: Option<HttpProxyOptions>, runtime: &Handle) -> MqttResult<AsyncGneissClient> {
     info!("make_direct_client_rustls - creating async connection establishment closure");
 
@@ -633,7 +633,7 @@ fn make_direct_client_rustls(endpoint: String, port: u16, tls_options: Option<Tl
     }
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "tokio-native-tls")]
 fn make_direct_client_native_tls(endpoint: String, port: u16, tls_options: Option<TlsOptions>, client_options: MqttClientOptions, connect_options: ConnectOptions, http_proxy_options: Option<HttpProxyOptions>, runtime: &Handle) -> MqttResult<AsyncGneissClient> {
     info!("make_direct_client_native_tls - creating async connection establishment closure");
 
@@ -700,19 +700,19 @@ fn make_direct_client_native_tls(endpoint: String, port: u16, tls_options: Optio
 }
 
 #[allow(clippy::too_many_arguments)]
-#[cfg(feature="websockets")]
+#[cfg(feature="tokio-websockets")]
 pub(crate) fn make_websocket_client(tls_impl: crate::config::TlsConfiguration, endpoint: String, port: u16, websocket_options: WebsocketOptions, _tls_options: Option<TlsOptions>, client_options: MqttClientOptions, connect_options: ConnectOptions, http_proxy_options: Option<HttpProxyOptions>, runtime: &Handle) -> MqttResult<AsyncGneissClient> {
     match tls_impl {
         crate::config::TlsConfiguration::None => { make_websocket_client_no_tls(endpoint, port, websocket_options, client_options, connect_options, http_proxy_options, runtime) }
-        #[cfg(feature = "rustls")]
+        #[cfg(feature = "tokio-rustls")]
         crate::config::TlsConfiguration::Rustls => { make_websocket_client_rustls(endpoint, port, websocket_options, _tls_options, client_options, connect_options, http_proxy_options, runtime) }
-        #[cfg(feature = "native-tls")]
+        #[cfg(feature = "tokio-native-tls")]
         crate::config::TlsConfiguration::Nativetls => { make_websocket_client_native_tls(endpoint, port, websocket_options, _tls_options, client_options, connect_options, http_proxy_options, runtime) }
         _ => { panic!("Illegal state"); }
     }
 }
 
-#[cfg(feature="websockets")]
+#[cfg(feature="tokio-websockets")]
 fn make_websocket_client_no_tls(endpoint: String, port: u16, websocket_options: WebsocketOptions, client_options: MqttClientOptions, connect_options: ConnectOptions, http_proxy_options: Option<HttpProxyOptions>, runtime: &Handle) -> MqttResult<AsyncGneissClient> {
     info!("make_websocket_client_no_tls - creating async connection establishment closure");
     let (stream_endpoint, http_connect_endpoint) = compute_endpoints(endpoint, port, &http_proxy_options);
@@ -743,7 +743,7 @@ fn make_websocket_client_no_tls(endpoint: String, port: u16, websocket_options: 
 }
 
 #[allow(clippy::too_many_arguments)]
-#[cfg(all(feature = "rustls", feature = "websockets"))]
+#[cfg(all(feature = "tokio-rustls", feature = "tokio-websockets"))]
 fn make_websocket_client_rustls(endpoint: String, port: u16, websocket_options: WebsocketOptions, tls_options: Option<TlsOptions>, client_options: MqttClientOptions, connect_options: ConnectOptions, http_proxy_options: Option<HttpProxyOptions>, runtime: &Handle) -> MqttResult<AsyncGneissClient> {
     info!("make_websocket_client_rustls - creating async connection establishment closure");
     let (stream_endpoint, http_connect_endpoint) = compute_endpoints(endpoint.clone(), port, &http_proxy_options);
@@ -813,7 +813,7 @@ fn make_websocket_client_rustls(endpoint: String, port: u16, websocket_options: 
 }
 
 #[allow(clippy::too_many_arguments)]
-#[cfg(all(feature = "native-tls", feature = "websockets"))]
+#[cfg(all(feature = "tokio-native-tls", feature = "tokio-websockets"))]
 fn make_websocket_client_native_tls(endpoint: String, port: u16, websocket_options: WebsocketOptions, tls_options: Option<TlsOptions>, client_options: MqttClientOptions, connect_options: ConnectOptions, http_proxy_options: Option<HttpProxyOptions>, runtime: &Handle) -> MqttResult<AsyncGneissClient> {
     info!("make_websocket_client_native_tls - creating async connection establishment closure");
     let (stream_endpoint, http_connect_endpoint) = compute_endpoints(endpoint.clone(), port, &http_proxy_options);
@@ -891,7 +891,7 @@ async fn make_leaf_stream(endpoint: Endpoint) -> MqttResult<TcpStream> {
     Ok(stream)
 }
 
-#[cfg(feature = "rustls")]
+#[cfg(feature = "tokio-rustls")]
 async fn wrap_stream_with_tls_rustls<S>(stream : Pin<Box<impl Future<Output=MqttResult<S>>+Sized>>, endpoint: String, tls_options: TlsOptions) -> MqttResult<tokio_rustls::client::TlsStream<S>> where S : AsyncRead + AsyncWrite + Unpin {
     let domain = rustls_pki_types::ServerName::try_from(endpoint)?
         .to_owned();
@@ -910,7 +910,7 @@ async fn wrap_stream_with_tls_rustls<S>(stream : Pin<Box<impl Future<Output=Mqtt
     Ok(tls_stream)
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "tokio-native-tls")]
 async fn wrap_stream_with_tls_native_tls<S>(stream : Pin<Box<impl Future<Output=MqttResult<S>>+Sized>>, endpoint: String, tls_options: TlsOptions) -> MqttResult<tokio_native_tls::TlsStream<S>> where S : AsyncRead + AsyncWrite + Unpin {
 
     let connector =
@@ -930,7 +930,7 @@ async fn wrap_stream_with_tls_native_tls<S>(stream : Pin<Box<impl Future<Output=
     Ok(tls_stream)
 }
 
-#[cfg(feature="websockets")]
+#[cfg(feature="tokio-websockets")]
 async fn wrap_stream_with_websockets<S>(stream : Pin<Box<impl Future<Output=MqttResult<S>>+Sized>>, endpoint: String, scheme: &str, websocket_options: WebsocketOptions) -> MqttResult<WsByteStream<WebSocketStream<S>, Message, tungstenite::Error, WsMessageHandler>> where S : AsyncRead + AsyncWrite + Unpin {
 
     let uri = format!("{}://{}/mqtt", scheme, endpoint); // scheme needs to be present but value irrelevant
@@ -1125,7 +1125,6 @@ pub(crate) mod testing {
     use assert_matches::assert_matches;
     use std::future::Future;
     use std::pin::Pin;
-    use std::sync::Arc;
     use std::time::Duration;
     use crate::client::waiter::*;
     use crate::config::*;
@@ -1147,7 +1146,7 @@ pub(crate) mod testing {
         builder.with_connect_options(connect_options);
         builder.with_client_options(client_config);
 
-        #[cfg(feature = "rustls")]
+        #[cfg(feature = "tokio-rustls")]
         if _tls_usage == TlsUsage::Rustls {
             let mut tls_options_builder = TlsOptionsBuilder::new();
             tls_options_builder.with_verify_peer(false);
@@ -1156,7 +1155,7 @@ pub(crate) mod testing {
             builder.with_tls_options(tls_options_builder.build_rustls().unwrap());
         }
 
-        #[cfg(feature = "native-tls")]
+        #[cfg(feature = "tokio-native-tls")]
         if _tls_usage == TlsUsage::Nativetls {
             let mut tls_options_builder = TlsOptionsBuilder::new();
             tls_options_builder.with_verify_peer(false);
@@ -1165,7 +1164,7 @@ pub(crate) mod testing {
             builder.with_tls_options(tls_options_builder.build_native_tls().unwrap());
         }
 
-        #[cfg(feature="websockets")]
+        #[cfg(feature="tokio-websockets")]
         if ws_config != WebsocketUsage::None {
             let websocket_options = WebsocketOptionsBuilder::new().build();
             builder.with_websocket_options(websocket_options);
@@ -1249,7 +1248,7 @@ pub(crate) mod testing {
     }
 
     async fn tokio_connect_disconnect_test(builder: GenericClientBuilder) -> MqttResult<()> {
-        let client = builder.build(&tokio::runtime::Handle::current()).unwrap();
+        let client = builder.build_tokio(&tokio::runtime::Handle::current()).unwrap();
 
         start_client(&client).await?;
         stop_client(&client).await?;
@@ -1265,7 +1264,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(feature = "rustls")]
+    #[cfg(feature = "tokio-rustls")]
     fn client_connect_disconnect_direct_rustls_no_proxy() {
         do_good_client_test(TlsUsage::Rustls, WebsocketUsage::None, ProxyUsage::None, Box::new(|builder|{
             Box::pin(tokio_connect_disconnect_test(builder))
@@ -1273,7 +1272,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "tokio-native-tls")]
     fn client_connect_disconnect_direct_native_tls_no_proxy() {
         do_good_client_test(TlsUsage::Nativetls, WebsocketUsage::None, ProxyUsage::None, Box::new(|builder|{
             Box::pin(tokio_connect_disconnect_test(builder))
@@ -1281,7 +1280,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(feature="websockets")]
+    #[cfg(feature="tokio-websockets")]
     fn client_connect_disconnect_websocket_plaintext_no_proxy() {
         do_good_client_test(TlsUsage::None, WebsocketUsage::Tungstenite, ProxyUsage::None, Box::new(|builder|{
             Box::pin(tokio_connect_disconnect_test(builder))
@@ -1289,7 +1288,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "rustls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-rustls", feature = "tokio-websockets"))]
     fn client_connect_disconnect_websocket_rustls_no_proxy() {
         do_good_client_test(TlsUsage::Rustls, WebsocketUsage::Tungstenite, ProxyUsage::None, Box::new(|builder|{
             Box::pin(tokio_connect_disconnect_test(builder))
@@ -1297,7 +1296,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "native-tls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-native-tls", feature = "tokio-websockets"))]
     fn client_connect_disconnect_websocket_native_tls_no_proxy() {
         do_good_client_test(TlsUsage::Nativetls, WebsocketUsage::Tungstenite, ProxyUsage::None, Box::new(|builder|{
             Box::pin(tokio_connect_disconnect_test(builder))
@@ -1312,7 +1311,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(feature = "rustls")]
+    #[cfg(feature = "tokio-rustls")]
     fn client_connect_disconnect_direct_rustls_with_proxy() {
         do_good_client_test(TlsUsage::Rustls, WebsocketUsage::None, ProxyUsage::Plaintext, Box::new(|builder|{
             Box::pin(tokio_connect_disconnect_test(builder))
@@ -1320,7 +1319,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "tokio-native-tls")]
     fn client_connect_disconnect_direct_native_tls_with_proxy() {
         do_good_client_test(TlsUsage::Nativetls, WebsocketUsage::None, ProxyUsage::Plaintext, Box::new(|builder|{
             Box::pin(tokio_connect_disconnect_test(builder))
@@ -1328,7 +1327,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(feature="websockets")]
+    #[cfg(feature="tokio-websockets")]
     fn client_connect_disconnect_websocket_plaintext_with_proxy() {
         do_good_client_test(TlsUsage::None, WebsocketUsage::Tungstenite, ProxyUsage::Plaintext, Box::new(|builder|{
             Box::pin(tokio_connect_disconnect_test(builder))
@@ -1336,7 +1335,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "rustls", feature="websosckets"))]
+    #[cfg(all(feature = "tokio-rustls", feature="websosckets"))]
     fn client_connect_disconnect_websocket_rustls_with_proxy() {
         do_good_client_test(TlsUsage::Rustls, WebsocketUsage::Tungstenite, ProxyUsage::Plaintext, Box::new(|builder|{
             Box::pin(tokio_connect_disconnect_test(builder))
@@ -1344,7 +1343,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "native-tls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-native-tls", feature = "tokio-websockets"))]
     fn client_connect_disconnect_websocket_native_tls_with_proxy() {
         do_good_client_test(TlsUsage::Nativetls, WebsocketUsage::Tungstenite, ProxyUsage::Plaintext, Box::new(|builder|{
             Box::pin(tokio_connect_disconnect_test(builder))
@@ -1352,7 +1351,7 @@ pub(crate) mod testing {
     }
 
     async fn tokio_subscribe_unsubscribe_test(builder: GenericClientBuilder) -> MqttResult<()> {
-        let client = builder.build(&tokio::runtime::Handle::current()).unwrap();
+        let client = builder.build_tokio(&tokio::runtime::Handle::current()).unwrap();
         start_client(&client).await?;
 
         let subscribe = SubscribePacket::builder()
@@ -1417,7 +1416,7 @@ pub(crate) mod testing {
     }
 
     async fn tokio_subscribe_publish_test(builder: GenericClientBuilder, qos: QualityOfService) -> MqttResult<()> {
-        let client = builder.build(&tokio::runtime::Handle::current()).unwrap();
+        let client = builder.build_tokio(&tokio::runtime::Handle::current()).unwrap();
         start_client(&client).await?;
 
         let payload = "derp".as_bytes().to_vec();
@@ -1478,7 +1477,7 @@ pub(crate) mod testing {
 
     // This primarily tests that the will configuration works.  Will functionality is mostly broker-side.
     async fn tokio_will_test(builder: GenericClientBuilder) -> MqttResult<()> {
-        let client = builder.build(&tokio::runtime::Handle::current()).unwrap();
+        let client = builder.build_tokio(&tokio::runtime::Handle::current()).unwrap();
         let payload = "Onsecondthought".as_bytes().to_vec();
 
         // tests are running in parallel, need a unique topic
@@ -1495,7 +1494,7 @@ pub(crate) mod testing {
             .build();
 
         let will_builder = create_client_builder_internal(connect_options, TlsUsage::None, WebsocketUsage::None, ProxyUsage::None, TlsUsage::None, WebsocketUsage::None);
-        let will_client = will_builder.build(&tokio::runtime::Handle::current()).unwrap();
+        let will_client = will_builder.build_tokio(&tokio::runtime::Handle::current()).unwrap();
 
         start_client(&client).await?;
         start_client(&will_client).await?;
@@ -1533,7 +1532,7 @@ pub(crate) mod testing {
     }
 
     async fn tokio_connect_disconnect_cycle_session_rejoin_test(builder: GenericClientBuilder) -> MqttResult<()> {
-        let client = builder.build(&tokio::runtime::Handle::current()).unwrap();
+        let client = builder.build_tokio(&tokio::runtime::Handle::current()).unwrap();
         start_client(&client).await?;
         stop_client(&client).await?;
 
@@ -1568,7 +1567,7 @@ pub(crate) mod testing {
     }
 
     async fn connection_failure_test(builder : GenericClientBuilder) -> MqttResult<()> {
-        let client = builder.build(&tokio::runtime::Handle::current()).unwrap();
+        let client = builder.build_tokio(&tokio::runtime::Handle::current()).unwrap();
         let mut connection_failure_waiter = ClientEventWaiter::new_single(client.clone(), ClientEventType::ConnectionFailure);
 
         client.start(None)?;
@@ -1588,7 +1587,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(feature = "rustls")]
+    #[cfg(feature = "tokio-rustls")]
     fn connection_failure_direct_rustls_tls_config_direct_plaintext_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::Rustls, WebsocketUsage::None, TlsUsage::None, WebsocketUsage::None);
         do_builder_test(Box::new(|builder| {
@@ -1597,7 +1596,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "tokio-native-tls")]
     fn connection_failure_direct_native_tls_tls_config_direct_plaintext_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::Nativetls, WebsocketUsage::None, TlsUsage::None, WebsocketUsage::None);
         do_builder_test(Box::new(|builder| {
@@ -1606,7 +1605,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "rustls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-rustls", feature = "tokio-websockets"))]
     fn connection_failure_direct_rustls_tls_config_websocket_plaintext_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::Rustls, WebsocketUsage::None, TlsUsage::None, WebsocketUsage::Tungstenite);
         do_builder_test(Box::new(|builder| {
@@ -1615,7 +1614,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "native-tls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-native-tls", feature = "tokio-websockets"))]
     fn connection_failure_direct_native_tls_tls_config_websocket_plaintext_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::Nativetls, WebsocketUsage::None, TlsUsage::None, WebsocketUsage::Tungstenite);
         do_builder_test(Box::new(|builder| {
@@ -1624,7 +1623,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "rustls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-rustls", feature = "tokio-websockets"))]
     fn connection_failure_direct_rustls_tls_config_websocket_tls_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::Rustls, WebsocketUsage::None, TlsUsage::Rustls, WebsocketUsage::Tungstenite);
         do_builder_test(Box::new(|builder| {
@@ -1633,7 +1632,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "native-tls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-native-tls", feature = "tokio-websockets"))]
     fn connection_failure_direct_native_tls_tls_config_websocket_tls_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::Nativetls, WebsocketUsage::None, TlsUsage::Nativetls, WebsocketUsage::Tungstenite);
         do_builder_test(Box::new(|builder| {
@@ -1642,7 +1641,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(feature = "rustls")]
+    #[cfg(feature = "tokio-rustls")]
     fn connection_failure_direct_plaintext_config_direct_rustls_tls_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::None, WebsocketUsage::None, TlsUsage::Rustls, WebsocketUsage::None);
         do_builder_test(Box::new(|builder| {
@@ -1651,7 +1650,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "tokio-native-tls")]
     fn connection_failure_direct_plaintext_config_direct_native_tls_tls_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::None, WebsocketUsage::None, TlsUsage::Nativetls, WebsocketUsage::None);
         do_builder_test(Box::new(|builder| {
@@ -1660,7 +1659,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(feature="websockets")]
+    #[cfg(feature="tokio-websockets")]
     fn connection_failure_direct_plaintext_config_websocket_plaintext_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::None, WebsocketUsage::None, TlsUsage::None, WebsocketUsage::Tungstenite);
         do_builder_test(Box::new(|builder| {
@@ -1669,7 +1668,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "rustls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-rustls", feature = "tokio-websockets"))]
     fn connection_failure_direct_plaintext_config_websocket_rustls_tls_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::None, WebsocketUsage::None, TlsUsage::Rustls, WebsocketUsage::Tungstenite);
         do_builder_test(Box::new(|builder| {
@@ -1678,7 +1677,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "native-tls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-native-tls", feature = "tokio-websockets"))]
     fn connection_failure_direct_plaintext_config_websocket_native_tls_tls_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::None, WebsocketUsage::None, TlsUsage::Nativetls, WebsocketUsage::Tungstenite);
         do_builder_test(Box::new(|builder| {
@@ -1687,7 +1686,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "rustls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-rustls", feature = "tokio-websockets"))]
     fn connection_failure_websocket_rustls_tls_config_direct_plaintext_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::Rustls, WebsocketUsage::Tungstenite, TlsUsage::None, WebsocketUsage::None);
         do_builder_test(Box::new(|builder| {
@@ -1696,7 +1695,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "native-tls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-native-tls", feature = "tokio-websockets"))]
     fn connection_failure_websocket_native_tls_tls_config_direct_plaintext_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::Nativetls, WebsocketUsage::Tungstenite, TlsUsage::None, WebsocketUsage::None);
         do_builder_test(Box::new(|builder| {
@@ -1705,7 +1704,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "rustls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-rustls", feature = "tokio-websockets"))]
     fn connection_failure_websocket_rustls_tls_config_websocket_plaintext_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::Rustls, WebsocketUsage::Tungstenite, TlsUsage::None, WebsocketUsage::Tungstenite);
         do_builder_test(Box::new(|builder| {
@@ -1714,7 +1713,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "native-tls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-native-tls", feature = "tokio-websockets"))]
     fn connection_failure_websocket_native_tls_tls_config_websocket_plaintext_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::Nativetls, WebsocketUsage::Tungstenite, TlsUsage::None, WebsocketUsage::Tungstenite);
         do_builder_test(Box::new(|builder| {
@@ -1723,7 +1722,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "rustls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-rustls", feature = "tokio-websockets"))]
     fn connection_failure_websocket_rustls_tls_config_direct_tls_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::Rustls, WebsocketUsage::Tungstenite, TlsUsage::Rustls, WebsocketUsage::None);
         do_builder_test(Box::new(|builder| {
@@ -1732,7 +1731,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "native-tls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-native-tls", feature = "tokio-websockets"))]
     fn connection_failure_websocket_native_tls_tls_config_direct_tls_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::Nativetls, WebsocketUsage::Tungstenite, TlsUsage::Nativetls, WebsocketUsage::None);
         do_builder_test(Box::new(|builder| {
@@ -1741,7 +1740,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(feature="websockets")]
+    #[cfg(feature="tokio-websockets")]
     fn connection_failure_websocket_plaintext_config_direct_plaintext_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::None, WebsocketUsage::Tungstenite, TlsUsage::None, WebsocketUsage::None);
         do_builder_test(Box::new(|builder| {
@@ -1750,7 +1749,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "rustls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-rustls", feature = "tokio-websockets"))]
     fn connection_failure_websocket_plaintext_config_websocket_rustls_tls_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::None, WebsocketUsage::Tungstenite, TlsUsage::Rustls, WebsocketUsage::Tungstenite);
         do_builder_test(Box::new(|builder| {
@@ -1759,7 +1758,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "native-tls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-native-tls", feature = "tokio-websockets"))]
     fn connection_failure_websocket_plaintext_config_websocket_native_tls_tls_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::None, WebsocketUsage::Tungstenite, TlsUsage::Nativetls, WebsocketUsage::Tungstenite);
         do_builder_test(Box::new(|builder| {
@@ -1768,7 +1767,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "rustls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-rustls", feature = "tokio-websockets"))]
     fn connection_failure_websocket_plaintext_config_direct_rustls_tls_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::None, WebsocketUsage::Tungstenite, TlsUsage::Rustls, WebsocketUsage::None);
         do_builder_test(Box::new(|builder| {
@@ -1777,7 +1776,7 @@ pub(crate) mod testing {
     }
 
     #[test]
-    #[cfg(all(feature = "native-tls", feature = "websockets"))]
+    #[cfg(all(feature = "tokio-native-tls", feature = "tokio-websockets"))]
     fn connection_failure_websocket_plaintext_config_direct_native_tls_tls_endpoint() {
         let builder = create_mismatch_builder(TlsUsage::None, WebsocketUsage::Tungstenite, TlsUsage::Nativetls, WebsocketUsage::None);
         do_builder_test(Box::new(|builder| {

--- a/gneiss-mqtt/src/features/mod.rs
+++ b/gneiss-mqtt/src/features/mod.rs
@@ -10,6 +10,7 @@ Module that encompasses feature-specific logic (primarily TLS and Async runtime)
 #[cfg(feature = "rustls")]
 pub mod gneiss_rustls;
 
+#[cfg(feature = "tokio")]
 pub mod gneiss_tokio;
 
 #[cfg(feature = "native-tls")]

--- a/gneiss-mqtt/src/features/mod.rs
+++ b/gneiss-mqtt/src/features/mod.rs
@@ -7,11 +7,11 @@
 Module that encompasses feature-specific logic (primarily TLS and Async runtime).
  */
 
-#[cfg(feature = "rustls")]
+#[cfg(feature = "tokio-rustls")]
 pub mod gneiss_rustls;
 
 #[cfg(feature = "tokio")]
 pub mod gneiss_tokio;
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "tokio-native-tls")]
 mod gneiss_native_tls;

--- a/gneiss-mqtt/src/lib.rs
+++ b/gneiss-mqtt/src/lib.rs
@@ -41,32 +41,36 @@ Currently, these crates include:
 supports all connection methods allowed by the AWS MQTT broker implementation,
 [AWS IoT Core](https://docs.aws.amazon.com/iot/latest/developerguide/iot-gs.html).
 
+*/
+
+#![cfg_attr(feature = "tokio", doc = r##"
 # Example: Connect to a local Mosquitto server
 
 Assuming a default Mosquitto installation, you can connect locally by plaintext on port 1883:
 
 ```no_run
-* use gneiss_mqtt::config::GenericClientBuilder;
-* use tokio::runtime::Handle;
-*
-* #[tokio::main]
-* async fn main() -> Result<(), Box<dyn std::error::Error>> {
-*
-*     // In the common case, you will not need a root CA certificate
-*     let client =
-*         GenericClientBuilder::new("127.0.0.1", 1883)
-*             .build_tokio(&Handle::current())?;
-*
-*     // Once started, the client will recurrently maintain a connection to the endpoint until
-*     // stop() is invoked
-*     client.start(None)?;
-*
-*     // <do stuff with the client>
-*
-*     Ok(())
-* }
-* ```
+use gneiss_mqtt::config::GenericClientBuilder;
+use tokio::runtime::Handle;
 
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+
+    // In the common case, you will not need a root CA certificate
+    let client =
+        GenericClientBuilder::new("127.0.0.1", 1883)
+            .build_tokio(&Handle::current())?;
+
+    // Once started, the client will recurrently maintain a connection to the endpoint until
+    // stop() is invoked
+    client.start(None)?;
+
+    // <do stuff with the client>
+
+    Ok(())
+}
+```"##)]
+
+/*!
 # Example: Subscribe to a topic
 
 In order to receive messages, you must first subscribe to the topics you want to receive messages for.  Subscribing
@@ -79,13 +83,13 @@ reason code vector to verify the success/failure result for each subscription in
 
 ```no_run
 use gneiss_mqtt::error::MqttResult;
-use gneiss_mqtt::client::{AsyncClient, SubscribeResult};
+use gneiss_mqtt::client::{AsyncGneissClient, SubscribeResult};
 use gneiss_mqtt::mqtt::{QualityOfService, SubscribePacket, Subscription};
 use std::sync::Arc;
 
-async fn subscribe_to_topic(client: Arc<dyn AsyncClient>) {
+async fn subscribe_to_topic(client: AsyncGneissClient) {
     let subscribe = SubscribePacket::builder()
-        .with_subscription(Subscription::builder("hello/world/+".to_string(), QualityOfService::AtLeastOnce).build())
+        .with_subscription(Subscription::new_simple("hello/world/+".to_string(), QualityOfService::AtLeastOnce))
         .build();
 
     let subscribe_result = client.subscribe(subscribe, None).await;
@@ -108,6 +112,9 @@ TODO
 
 TODO
 
+*/
+
+#![cfg_attr(feature = "tokio", doc = r##"
 # Example: React to client events
 In addition to performing MQTT operations with the client, you can also react to events emitted by the
 client.  The client emits events when connectivity changes (successful connection, failed connection, disconnection,
@@ -159,7 +166,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // put the client in an Arc so we can capture an Arc clone in the event handler closure
     let client : AsyncGneissClient =
         GenericClientBuilder::new("127.0.0.1", 1883)
-            .build(&Handle::current())?;
+            .build_tokio(&Handle::current())?;
 
     // make a client event handler closure
     let closure_client = client.clone();
@@ -173,8 +180,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-```
+```"##)]
 
+/*!
 # Additional Notes
 
 The intention is that this crate will eventually be as agnostic as possible of underlying

--- a/gneiss-mqtt/src/lib.rs
+++ b/gneiss-mqtt/src/lib.rs
@@ -46,26 +46,26 @@ supports all connection methods allowed by the AWS MQTT broker implementation,
 Assuming a default Mosquitto installation, you can connect locally by plaintext on port 1883:
 
 ```no_run
-use gneiss_mqtt::config::GenericClientBuilder;
-use tokio::runtime::Handle;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-
-    // In the common case, you will not need a root CA certificate
-    let client =
-        GenericClientBuilder::new("127.0.0.1", 1883)
-            .build(&Handle::current())?;
-
-    // Once started, the client will recurrently maintain a connection to the endpoint until
-    // stop() is invoked
-    client.start(None)?;
-
-    // <do stuff with the client>
-
-    Ok(())
-}
-```
+* use gneiss_mqtt::config::GenericClientBuilder;
+* use tokio::runtime::Handle;
+*
+* #[tokio::main]
+* async fn main() -> Result<(), Box<dyn std::error::Error>> {
+*
+*     // In the common case, you will not need a root CA certificate
+*     let client =
+*         GenericClientBuilder::new("127.0.0.1", 1883)
+*             .build_tokio(&Handle::current())?;
+*
+*     // Once started, the client will recurrently maintain a connection to the endpoint until
+*     // stop() is invoked
+*     client.start(None)?;
+*
+*     // <do stuff with the client>
+*
+*     Ok(())
+* }
+* ```
 
 # Example: Subscribe to a topic
 
@@ -121,11 +121,11 @@ operations in reaction to client events (the client's public API is immutable). 
 every time we receive a "Ping" publish:
 
 ```no_run
-use gneiss_mqtt::client::{ClientEvent, AsyncMqttClient};
+use gneiss_mqtt::client::{ClientEvent, AsyncGneissClient};
 use gneiss_mqtt::mqtt::{PublishPacket, QualityOfService};
 use std::sync::Arc;
 
-pub fn client_event_callback(client: AsyncMqttClient, event: Arc<ClientEvent>) {
+pub fn client_event_callback(client: AsyncGneissClient, event: Arc<ClientEvent>) {
     if let ClientEvent::PublishReceived(publish_received_event) = event.as_ref() {
         let publish = &publish_received_event.publish;
         if let Some(payload) = publish.payload() {
@@ -157,7 +157,7 @@ use tokio::runtime::Handle;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // put the client in an Arc so we can capture an Arc clone in the event handler closure
-    let client : AsyncMqttClient =
+    let client : AsyncGneissClient =
         GenericClientBuilder::new("127.0.0.1", 1883)
             .build(&Handle::current())?;
 

--- a/gneiss-mqtt/src/mqtt/mod.rs
+++ b/gneiss-mqtt/src/mqtt/mod.rs
@@ -686,6 +686,11 @@ impl Subscription {
         SubscriptionBuilder::new(topic_filter, qos)
     }
 
+    /// Creates a new subscription using only required options
+    pub fn new_simple(topic_filter: String, qos: QualityOfService) -> Subscription {
+        SubscriptionBuilder::new(topic_filter, qos).build()
+    }
+
     /// Returns the topic filter to subscribe to
     ///
     /// See [MQTT5 Subscription Options](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901169)

--- a/gneiss-mqtt/src/protocol.rs
+++ b/gneiss-mqtt/src/protocol.rs
@@ -2006,23 +2006,23 @@ fn complete_operation_with_result(operation_options: &mut MqttOperationOptions, 
                 }
             }
 
-            let sender = publish_options.response_sender.take().unwrap();
-            let _ = sender.send(Ok(publish_response));
+            let handler = publish_options.response_handler.take().unwrap();
+            let _ = handler(Ok(publish_response));
 
             return Ok(());
         }
         MqttOperationOptions::Subscribe(subscribe_options) => {
             if let OperationResponse::Subscribe(suback) = completion_result.unwrap() {
-                let sender = subscribe_options.response_sender.take().unwrap();
-                let _ = sender.send(Ok(suback));
+                let handler = subscribe_options.response_handler.take().unwrap();
+                let _ = handler(Ok(suback));
 
                 return Ok(());
             }
         }
         MqttOperationOptions::Unsubscribe(unsubscribe_options) => {
             if let OperationResponse::Unsubscribe(unsuback) = completion_result.unwrap() {
-                let sender = unsubscribe_options.response_sender.take().unwrap();
-                let _ = sender.send(Ok(unsuback));
+                let handler = unsubscribe_options.response_handler.take().unwrap();
+                let _ = handler(Ok(unsuback));
 
                 return Ok(());
             }
@@ -2035,16 +2035,16 @@ fn complete_operation_with_result(operation_options: &mut MqttOperationOptions, 
 fn complete_operation_with_error(operation_options: &mut MqttOperationOptions, error: MqttError) -> MqttResult<()> {
     match operation_options {
         MqttOperationOptions::Publish(publish_options) => {
-            let sender = publish_options.response_sender.take().unwrap();
-            let _ = sender.send(Err(error));
+            let handler = publish_options.response_handler.take().unwrap();
+            let _ = handler(Err(error));
         }
         MqttOperationOptions::Subscribe(subscribe_options) => {
-            let sender = subscribe_options.response_sender.take().unwrap();
-            let _ = sender.send(Err(error));
+            let handler = subscribe_options.response_handler.take().unwrap();
+            let _ = handler(Err(error));
         }
         MqttOperationOptions::Unsubscribe(unsubscribe_options) => {
-            let sender = unsubscribe_options.response_sender.take().unwrap();
-            let _ = sender.send(Err(error));
+            let handler = unsubscribe_options.response_handler.take().unwrap();
+            let _ = handler(Err(error));
         }
     }
 

--- a/gneiss-mqtt/src/testing/integration.rs
+++ b/gneiss-mqtt/src/testing/integration.rs
@@ -9,10 +9,10 @@ use std::env;
 pub(crate) enum TlsUsage {
     None,
 
-    #[cfg(feature = "rustls")]
+    #[cfg(feature = "tokio-rustls")]
     Rustls,
 
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "tokio-native-tls")]
     Nativetls
 }
 
@@ -20,7 +20,7 @@ pub(crate) enum TlsUsage {
 pub(crate) enum WebsocketUsage {
     None,
 
-    #[cfg(feature="websockets")]
+    #[cfg(feature="tokio-websockets")]
     Tungstenite
 }
 
@@ -30,7 +30,7 @@ pub(crate) enum ProxyUsage {
     Plaintext
 }
 
-#[cfg(feature = "rustls")]
+#[cfg(feature = "tokio-rustls")]
 pub(crate) fn get_ca_path() -> String {
     env::var("GNEISS_MQTT_TEST_BROKER_CA_PATH").unwrap()
 }

--- a/gneiss-mqtt/src/testing/mock_server.rs
+++ b/gneiss-mqtt/src/testing/mock_server.rs
@@ -14,7 +14,7 @@ use std::io::ErrorKind::{TimedOut, WouldBlock, Interrupted};
 use std::net::{Shutdown, TcpListener, TcpStream};
 use std::time::Duration;
 use crate::alias::OutboundAliasResolution;
-use crate::config::{ConnectOptionsBuilder, GenericClientBuilder, Mqtt5ClientOptionsBuilder};
+use crate::config::{ConnectOptionsBuilder, GenericClientBuilder, MqttClientOptionsBuilder};
 use crate::mqtt::utils::mqtt_packet_to_packet_type;
 use crate::testing::protocol::*;
 use std::sync::{Arc, Mutex};
@@ -207,7 +207,7 @@ impl MockBroker {
 pub(crate) struct ClientTestOptions {
     pub(crate) packet_handler_set_factory_fn: Option<PacketHandlerSetFactory>,
 
-    pub(crate) client_options_mutator_fn: Option<Box<dyn Fn(&mut Mqtt5ClientOptionsBuilder)>>,
+    pub(crate) client_options_mutator_fn: Option<Box<dyn Fn(&mut MqttClientOptionsBuilder)>>,
 
     pub(crate) connect_options_mutator_fn: Option<Box<dyn Fn(&mut ConnectOptionsBuilder)>>
 }
@@ -222,7 +222,7 @@ pub(crate) fn build_mock_client_server(mut config: ClientTestOptions) -> (Generi
 
     let broker = MockBroker::new(handler_set_factory);
 
-    let mut client_options_builder = Mqtt5ClientOptionsBuilder::new();
+    let mut client_options_builder = MqttClientOptionsBuilder::new();
     client_options_builder.with_connect_timeout(Duration::from_secs(3));
 
     if let Some(client_options_mutator) = config.client_options_mutator_fn {

--- a/gneiss-mqtt/src/testing/protocol.rs
+++ b/gneiss-mqtt/src/testing/protocol.rs
@@ -614,9 +614,12 @@ impl ProtocolStateTestFixture {
     pub(crate) fn subscribe(&mut self, elapsed_millis: u64, subscribe: SubscribePacket, options: SubscribeOptions) -> MqttResult<AsyncOperationReceiver<SubscribeResult>> {
         let (sender, receiver) = AsyncOperationChannel::new().split();
         let packet = Box::new(MqttPacket::Subscribe(subscribe));
+        let handler: ResponseHandler<SubscribeResult> = Box::new(move |res| {
+            sender.send(res)
+        });
         let subscribe_options = SubscribeOptionsInternal {
             options,
-            response_sender : Some(sender)
+            response_handler : Some(handler)
         };
 
         let subscribe_event = UserEvent::Subscribe(packet, subscribe_options);
@@ -632,9 +635,12 @@ impl ProtocolStateTestFixture {
     pub(crate) fn unsubscribe(&mut self, elapsed_millis: u64, unsubscribe: UnsubscribePacket, options: UnsubscribeOptions) -> MqttResult<AsyncOperationReceiver<UnsubscribeResult>> {
         let (sender, receiver) = AsyncOperationChannel::new().split();
         let packet = Box::new(MqttPacket::Unsubscribe(unsubscribe));
+        let handler : ResponseHandler<UnsubscribeResult> = Box::new(move |res| {
+            sender.send(res)
+        });
         let unsubscribe_options = UnsubscribeOptionsInternal {
             options,
-            response_sender : Some(sender)
+            response_handler : Some(handler)
         };
 
         let unsubscribe_event = UserEvent::Unsubscribe(packet, unsubscribe_options);
@@ -650,9 +656,12 @@ impl ProtocolStateTestFixture {
     pub(crate) fn publish(&mut self, elapsed_millis: u64, publish: PublishPacket, options: PublishOptions) -> MqttResult<AsyncOperationReceiver<PublishResult>> {
         let (sender, receiver) = AsyncOperationChannel::new().split();
         let packet = Box::new(MqttPacket::Publish(publish));
+        let handler : ResponseHandler<PublishResult> = Box::new(move |res| {
+            sender.send(res)
+        });
         let publish_options = PublishOptionsInternal {
             options,
-            response_sender : Some(sender)
+            response_handler : Some(handler)
         };
 
         let publish_event = UserEvent::Publish(packet, publish_options);

--- a/gneiss-mqtt/src/testing/protocol.rs
+++ b/gneiss-mqtt/src/testing/protocol.rs
@@ -6,7 +6,6 @@
 use std::cmp::Ordering;
 use std::collections::{HashMap, VecDeque};
 use std::time::{Duration, Instant};
-use crate::features::gneiss_tokio::*;
 use crate::protocol::*;
 use assert_matches::assert_matches;
 use crate::alias::{OutboundAliasResolution, OutboundAliasResolverFactory};
@@ -611,11 +610,12 @@ impl ProtocolStateTestFixture {
         None
     }
 
-    pub(crate) fn subscribe(&mut self, elapsed_millis: u64, subscribe: SubscribePacket, options: SubscribeOptions) -> MqttResult<AsyncOperationReceiver<SubscribeResult>> {
-        let (sender, receiver) = AsyncOperationChannel::new().split();
+    pub(crate) fn subscribe(&mut self, elapsed_millis: u64, subscribe: SubscribePacket, options: SubscribeOptions) -> MqttResult<std::sync::mpsc::Receiver<SubscribeResult>> {
+        let (sender, receiver) = std::sync::mpsc::channel();
         let packet = Box::new(MqttPacket::Subscribe(subscribe));
         let handler: ResponseHandler<SubscribeResult> = Box::new(move |res| {
-            sender.send(res)
+            sender.send(res)?;
+            Ok(())
         });
         let subscribe_options = SubscribeOptionsInternal {
             options,
@@ -632,11 +632,12 @@ impl ProtocolStateTestFixture {
         Ok(receiver)
     }
 
-    pub(crate) fn unsubscribe(&mut self, elapsed_millis: u64, unsubscribe: UnsubscribePacket, options: UnsubscribeOptions) -> MqttResult<AsyncOperationReceiver<UnsubscribeResult>> {
-        let (sender, receiver) = AsyncOperationChannel::new().split();
+    pub(crate) fn unsubscribe(&mut self, elapsed_millis: u64, unsubscribe: UnsubscribePacket, options: UnsubscribeOptions) -> MqttResult<std::sync::mpsc::Receiver<UnsubscribeResult>> {
+        let (sender, receiver) = std::sync::mpsc::channel();
         let packet = Box::new(MqttPacket::Unsubscribe(unsubscribe));
         let handler : ResponseHandler<UnsubscribeResult> = Box::new(move |res| {
-            sender.send(res)
+            sender.send(res)?;
+            Ok(())
         });
         let unsubscribe_options = UnsubscribeOptionsInternal {
             options,
@@ -653,11 +654,12 @@ impl ProtocolStateTestFixture {
         Ok(receiver)
     }
 
-    pub(crate) fn publish(&mut self, elapsed_millis: u64, publish: PublishPacket, options: PublishOptions) -> MqttResult<AsyncOperationReceiver<PublishResult>> {
-        let (sender, receiver) = AsyncOperationChannel::new().split();
+    pub(crate) fn publish(&mut self, elapsed_millis: u64, publish: PublishPacket, options: PublishOptions) -> MqttResult<std::sync::mpsc::Receiver<PublishResult>> {
+        let (sender, receiver) = std::sync::mpsc::channel();
         let packet = Box::new(MqttPacket::Publish(publish));
         let handler : ResponseHandler<PublishResult> = Box::new(move |res| {
-            sender.send(res)
+            sender.send(res)?;
+            Ok(())
         });
         let publish_options = PublishOptionsInternal {
             options,
@@ -1373,7 +1375,7 @@ fn do_subscribe_success(fixture : &mut ProtocolStateTestFixture, transmission_ti
         panic!("Expected subscribe");
     }
 
-    let result = subscribe_result_receiver.blocking_recv();
+    let result = subscribe_result_receiver.recv();
     assert!(!result.is_err());
 
     let subscribe_result = result.unwrap();
@@ -1418,7 +1420,7 @@ fn do_publish_success(fixture : &mut ProtocolStateTestFixture, qos: QualityOfSer
         assert!(fixture.service_round_trip(response_time, response_time, 4096).is_ok());
     }
 
-    let result = publish_result_receiver.blocking_recv();
+    let result = publish_result_receiver.recv();
     assert!(!result.is_err());
 
     let op_result = result.unwrap();
@@ -1491,7 +1493,7 @@ fn do_unsubscribe_success(fixture : &mut ProtocolStateTestFixture, transmission_
         panic!("Expected unsubscribe");
     }
 
-    let result = unsubscribe_result_receiver.blocking_recv();
+    let result = unsubscribe_result_receiver.recv();
     assert!(!result.is_err());
 
     let unsubscribe_result = result.unwrap();
@@ -1682,7 +1684,7 @@ macro_rules! define_operation_success_reconnect_while_in_user_queue_test {
 
                 let operation = $build_operation_function_name();
 
-                let mut operation_result_receiver = fixture.$operation_api(0, operation.clone(), $operation_options_type{ ..Default::default()}).unwrap();
+                let operation_result_receiver = fixture.$operation_api(0, operation.clone(), $operation_options_type{ ..Default::default()}).unwrap();
                 assert!(operation_result_receiver.try_recv().is_err());
                 assert_eq!(1, fixture.client_state.user_operation_queue.len());
 
@@ -1697,7 +1699,7 @@ macro_rules! define_operation_success_reconnect_while_in_user_queue_test {
                 assert!(fixture.service_round_trip(10, 20, 4096).is_ok());
                 assert!(fixture.service_round_trip(30, 40, 4096).is_ok()); // qos 2
 
-                if let Ok(Ok(ack)) = operation_result_receiver.blocking_recv() {
+                if let Ok(Ok(ack)) = operation_result_receiver.recv() {
                     $verify_function_name(&ack);
                 } else {
                     panic!("Expected ack result");
@@ -1869,7 +1871,7 @@ macro_rules! define_operation_success_reconnect_while_current_operation_test {
 
                 let operation = $build_operation_function_name();
 
-                let mut operation_result_receiver = fixture.$operation_api(0, operation.clone(), $operation_options_type{ ..Default::default()}).unwrap();
+                let operation_result_receiver = fixture.$operation_api(0, operation.clone(), $operation_options_type{ ..Default::default()}).unwrap();
                 assert!(operation_result_receiver.try_recv().is_err());
                 assert_eq!(1, fixture.client_state.user_operation_queue.len());
 
@@ -1890,7 +1892,7 @@ macro_rules! define_operation_success_reconnect_while_current_operation_test {
                 assert!(fixture.service_round_trip(10, 20, 4096).is_ok());
                 assert!(fixture.service_round_trip(30, 40, 4096).is_ok()); // qos 2
 
-                if let Ok(Ok(ack)) = operation_result_receiver.blocking_recv() {
+                if let Ok(Ok(ack)) = operation_result_receiver.recv() {
                     $verify_function_name(&ack);
                 } else {
                     panic!("Expected ack result");
@@ -1982,7 +1984,7 @@ macro_rules! define_operation_success_reconnect_no_session_while_pending_test {
 
                 let operation = $build_operation_function_name();
 
-                let mut operation_result_receiver = fixture.$operation_api(0, operation.clone(), $operation_options_type{ ..Default::default()}).unwrap();
+                let operation_result_receiver = fixture.$operation_api(0, operation.clone(), $operation_options_type{ ..Default::default()}).unwrap();
                 assert!(operation_result_receiver.try_recv().is_err());
                 assert_eq!(1, fixture.client_state.user_operation_queue.len());
 
@@ -2008,7 +2010,7 @@ macro_rules! define_operation_success_reconnect_no_session_while_pending_test {
                 assert!(fixture.service_round_trip(10, 20, 4096).is_ok());
                 assert!(fixture.service_round_trip(30, 40, 4096).is_ok()); // qos 2
 
-                if let Ok(Ok(ack)) = operation_result_receiver.blocking_recv() {
+                if let Ok(Ok(ack)) = operation_result_receiver.recv() {
                     $verify_function_name(&ack);
                 } else {
                     panic!("Expected ack result");
@@ -2161,7 +2163,7 @@ macro_rules! define_operation_failure_validation_helper {
                 let operation_result_receiver = fixture.$operation_api(0, packet, $operation_options_type{ ..Default::default() }).unwrap();
                 assert!(fixture.service_round_trip(0, 0, 4096).is_ok());
 
-                let result = operation_result_receiver.blocking_recv();
+                let result = operation_result_receiver.recv();
                 assert!(!result.is_err());
 
                 let operation_result = result.unwrap();
@@ -2297,7 +2299,7 @@ macro_rules! define_operation_failure_timeout_helper {
 
                 let packet = $build_operation_function_name();
 
-                let mut operation_result_receiver = fixture.$operation_api(0, packet, $operation_options_type_builder::new().with_timeout(Duration::from_secs(30)).build()).unwrap();
+                let operation_result_receiver = fixture.$operation_api(0, packet, $operation_options_type_builder::new().with_timeout(Duration::from_secs(30)).build()).unwrap();
                 assert!(fixture.service_round_trip(0, 0, 4096).is_ok());
 
                 let (index, _) = find_nth_packet_of_type(fixture.to_broker_packet_stream.iter(), PacketType::$packet_type, 1, None, None).unwrap();
@@ -2309,11 +2311,14 @@ macro_rules! define_operation_failure_timeout_helper {
                     let elapsed_millis = i * 1000;
                     assert_eq!(Some(30000), fixture.get_next_service_time(elapsed_millis));
                     assert!(fixture.service_round_trip(elapsed_millis, elapsed_millis, 4096).is_ok());
-                    assert_matches!(operation_result_receiver.try_recv(), Err(MqttError::OperationChannelFailure(_)));
+                    let recv_result = operation_result_receiver.try_recv();
+                    assert!(recv_result.is_err());
+                    let mqtt_error = MqttError::from(recv_result.unwrap_err());
+                    assert_matches!(mqtt_error, MqttError::OperationChannelFailure(_));
                 }
 
                 assert!(fixture.service_round_trip(30000, 30000, 4096).is_ok());
-                let result = operation_result_receiver.blocking_recv();
+                let result = operation_result_receiver.recv();
                 assert_matches!(result.unwrap().unwrap_err(), MqttError::AckTimeout(_));
                 verify_protocol_state_empty(&fixture);
             }
@@ -2381,7 +2386,7 @@ fn connected_state_qos2_publish_failure_pubrel_timeout() {
 
     let packet = build_qos2_publish_success_packet();
 
-    let mut operation_result_receiver = fixture.publish(0, packet, PublishOptionsBuilder::new().with_timeout(Duration::from_secs(30)).build()).unwrap();
+    let operation_result_receiver = fixture.publish(0, packet, PublishOptionsBuilder::new().with_timeout(Duration::from_secs(30)).build()).unwrap();
     assert!(fixture.service_round_trip(0, 0, 4096).is_ok());
     assert!(fixture.service_round_trip(10, 10, 4096).is_ok());
 
@@ -2397,11 +2402,12 @@ fn connected_state_qos2_publish_failure_pubrel_timeout() {
         let elapsed_millis = i * 1000;
         assert_eq!(Some(30000), fixture.get_next_service_time(elapsed_millis));
         assert!(fixture.service_round_trip(elapsed_millis, elapsed_millis, 4096).is_ok());
-        assert_matches!(operation_result_receiver.try_recv(), Err(MqttError::OperationChannelFailure(_)));
+        let error = MqttError::from(operation_result_receiver.try_recv().unwrap_err());
+        assert_matches!(error, MqttError::OperationChannelFailure(_));
     }
 
     assert!(fixture.service_round_trip(30000, 30000, 4096).is_ok());
-    let result = operation_result_receiver.blocking_recv();
+    let result = operation_result_receiver.recv();
     assert_matches!(result.unwrap().unwrap_err(), MqttError::AckTimeout(_));
     assert!(fixture.service_round_trip(30010, 30010, 4096).is_ok());
     verify_protocol_state_empty(&fixture);
@@ -2419,7 +2425,7 @@ macro_rules! define_operation_failure_offline_submit_and_policy_fail_helper {
 
                 let operation_result_receiver = fixture.$operation_api(0, packet, $operation_options_type{ ..Default::default() }).unwrap();
 
-                let result = operation_result_receiver.blocking_recv();
+                let result = operation_result_receiver.recv();
                 assert!(!result.is_err());
 
                 let operation_result = result.unwrap();
@@ -2507,7 +2513,7 @@ macro_rules! define_operation_failure_disconnect_user_queue_with_failing_offline
 
                 let packet = $build_operation_function_name();
 
-                let mut operation_result_receiver = fixture.$operation_api(0, packet, $operation_options_type{ ..Default::default() }).unwrap();
+                let operation_result_receiver = fixture.$operation_api(0, packet, $operation_options_type{ ..Default::default() }).unwrap();
 
                 assert!(operation_result_receiver.try_recv().is_err());
                 assert_eq!(1, fixture.client_state.user_operation_queue.len());
@@ -2515,7 +2521,7 @@ macro_rules! define_operation_failure_disconnect_user_queue_with_failing_offline
                 assert!(fixture.on_connection_closed(0).is_ok());
                 verify_protocol_state_empty(&fixture);
 
-                let result = operation_result_receiver.blocking_recv();
+                let result = operation_result_receiver.recv();
                 assert!(!result.is_err());
 
                 let operation_result = result.unwrap();
@@ -2603,7 +2609,7 @@ macro_rules! define_operation_failure_disconnect_current_operation_with_failing_
 
                 let packet = $build_operation_function_name();
 
-                let mut operation_result_receiver = fixture.$operation_api(0, packet, $operation_options_type{ ..Default::default() }).unwrap();
+                let operation_result_receiver = fixture.$operation_api(0, packet, $operation_options_type{ ..Default::default() }).unwrap();
 
                 assert!(operation_result_receiver.try_recv().is_err());
                 assert_eq!(1, fixture.client_state.user_operation_queue.len());
@@ -2617,7 +2623,7 @@ macro_rules! define_operation_failure_disconnect_current_operation_with_failing_
                 assert!(fixture.on_connection_closed(0).is_ok());
                 verify_protocol_state_empty(&fixture);
 
-                let result = operation_result_receiver.blocking_recv();
+                let result = operation_result_receiver.recv();
                 assert!(!result.is_err());
 
                 let operation_result = result.unwrap();
@@ -2705,7 +2711,7 @@ macro_rules! define_operation_failure_disconnect_pending_with_failing_offline_po
 
                 let packet = $build_operation_function_name();
 
-                let mut operation_result_receiver = fixture.$operation_api(0, packet, $operation_options_type{ ..Default::default() }).unwrap();
+                let operation_result_receiver = fixture.$operation_api(0, packet, $operation_options_type{ ..Default::default() }).unwrap();
 
                 assert!(operation_result_receiver.try_recv().is_err());
                 assert_eq!(1, fixture.client_state.user_operation_queue.len());
@@ -2723,7 +2729,7 @@ macro_rules! define_operation_failure_disconnect_pending_with_failing_offline_po
                 assert!(fixture.on_connection_closed(0).is_ok());
                 verify_protocol_state_empty(&fixture);
 
-                let result = operation_result_receiver.blocking_recv();
+                let result = operation_result_receiver.recv();
                 assert!(!result.is_err());
 
                 let operation_result = result.unwrap();
@@ -2785,7 +2791,7 @@ macro_rules! define_acked_publish_failure_disconnect_pending_no_session_resumpti
 
                 let packet = $build_operation_function_name();
 
-                let mut operation_result_receiver = fixture.publish(0, packet, PublishOptions{ ..Default::default() }).unwrap();
+                let operation_result_receiver = fixture.publish(0, packet, PublishOptions{ ..Default::default() }).unwrap();
 
                 assert!(operation_result_receiver.try_recv().is_err());
                 assert_eq!(1, fixture.client_state.user_operation_queue.len());
@@ -2819,7 +2825,7 @@ macro_rules! define_acked_publish_failure_disconnect_pending_no_session_resumpti
                 assert!(fixture.service_round_trip(20, 30, 4096).is_ok());
                 assert!(fixture.service_round_trip(40, 50, 4096).is_ok());
 
-                let result = operation_result_receiver.blocking_recv();
+                let result = operation_result_receiver.recv();
                 assert!(!result.is_err());
 
                 let operation_result = result.unwrap();
@@ -2877,7 +2883,7 @@ macro_rules! define_acked_publish_success_disconnect_pending_with_session_resump
 
                 let packet = $build_operation_function_name();
 
-                let mut operation_result_receiver = fixture.publish(0, packet, PublishOptions{ ..Default::default() }).unwrap();
+                let operation_result_receiver = fixture.publish(0, packet, PublishOptions{ ..Default::default() }).unwrap();
 
                 assert!(operation_result_receiver.try_recv().is_err());
                 assert_eq!(1, fixture.client_state.user_operation_queue.len());
@@ -2916,7 +2922,7 @@ macro_rules! define_acked_publish_success_disconnect_pending_with_session_resump
                 assert!(fixture.service_round_trip(40, 50, 4096).is_ok()); // publish -> puback/pubrec
                 assert!(fixture.service_round_trip(60, 70, 4096).is_ok()); // Optional: pubrel -> pubcomp
 
-                let result = operation_result_receiver.blocking_recv();
+                let result = operation_result_receiver.recv();
                 assert!(!result.is_err());
 
                 let operation_result = result.unwrap().unwrap();
@@ -3307,9 +3313,9 @@ fn connected_state_maximum_inflight_publish_limit_respected() {
         ..Default::default()
     };
 
-    let mut result1 = fixture.publish(10, publish1, PublishOptions{ ..Default::default() }).unwrap();
-    let mut result2 = fixture.publish(10, publish2, PublishOptions{ ..Default::default() }).unwrap();
-    let mut result3 = fixture.publish(10, publish3, PublishOptions{ ..Default::default() }).unwrap();
+    let result1 = fixture.publish(10, publish1, PublishOptions{ ..Default::default() }).unwrap();
+    let result2 = fixture.publish(10, publish2, PublishOptions{ ..Default::default() }).unwrap();
+    let result3 = fixture.publish(10, publish3, PublishOptions{ ..Default::default() }).unwrap();
 
     let response1a_bytes = fixture.service_with_drain(20, 4096).unwrap();
     assert!(fixture.get_next_service_time(20).is_none());
@@ -3552,9 +3558,9 @@ struct MultiOperationContext {
     outbound_packets: Vec<MqttPacket>,
     to_client_bytes: Vec<u8>,
 
-    publish_receivers: HashMap<u64, AsyncOperationReceiver<PublishResult>>,
-    subscribe_receivers: HashMap<u64, AsyncOperationReceiver<SubscribeResult>>,
-    unsubscribe_receivers: HashMap<u64, AsyncOperationReceiver<UnsubscribeResult>>,
+    publish_receivers: HashMap<u64, std::sync::mpsc::Receiver<PublishResult>>,
+    subscribe_receivers: HashMap<u64, std::sync::mpsc::Receiver<SubscribeResult>>,
+    unsubscribe_receivers: HashMap<u64, std::sync::mpsc::Receiver<UnsubscribeResult>>,
 }
 
 impl MultiOperationContext {
@@ -4145,7 +4151,7 @@ fn connected_state_disconnect_with_high_priority_pubrel() {
         ..Default::default()
     };
 
-    let mut receiver = fixture.publish(100, publish, PublishOptions{ ..Default::default() }).unwrap();
+    let receiver = fixture.publish(100, publish, PublishOptions{ ..Default::default() }).unwrap();
 
     assert!(fixture.service_round_trip(150, 200, 4096).is_ok());
     assert_eq!(1, fixture.client_state.high_priority_operation_queue.len());


### PR DESCRIPTION
* A lot of renaming and refactoring
* Refactors existing features to be paired with a client selection due to cargo limits on feature control
* Initial tokio client feature support
* Fixes a timing-based flush bug that could trip an assert if another future got ran between a socket write and its associated flush.  Now flush is called outside the core select that runs the async client in its connected state.