### PR TITLE
Small TLS support polish

### DIFF
--- a/gneiss-mqtt/src/config.rs
+++ b/gneiss-mqtt/src/config.rs
@@ -129,10 +129,10 @@ pub(crate) enum TlsData {
     Invalid,
 
     #[cfg(feature = "tokio-rustls")]
-    Rustls(TlsMode, std::sync::Arc<rustls::ClientConfig>),
+    Rustls(std::sync::Arc<rustls::ClientConfig>),
 
     #[cfg(feature = "tokio-native-tls")]
-    NativeTls(TlsMode, std::sync::Arc<native_tls::TlsConnectorBuilder>)
+    NativeTls(std::sync::Arc<native_tls::TlsConnectorBuilder>)
 }
 
 /// Opaque struct containing TLS configuration data, assuming TLS has been enabled as a feature
@@ -760,9 +760,9 @@ fn get_tls_impl_from_options(tls_options: Option<&TlsOptions>) -> TlsConfigurati
         return
             match &tls_opts.options {
                 #[cfg(feature = "tokio-rustls")]
-                TlsData::Rustls(_, _) => { TlsConfiguration::Rustls }
+                TlsData::Rustls(_) => { TlsConfiguration::Rustls }
                 #[cfg(feature = "tokio-native-tls")]
-                TlsData::NativeTls(_, _) => { TlsConfiguration::Nativetls }
+                TlsData::NativeTls(_) => { TlsConfiguration::Nativetls }
                 _ => { TlsConfiguration::None }
             };
     }

--- a/gneiss-mqtt/src/features/gneiss_native_tls.rs
+++ b/gneiss-mqtt/src/features/gneiss_native_tls.rs
@@ -37,7 +37,16 @@ impl TlsOptionsBuilder {
         builder.use_sni(self.verify_peer);
 
         Ok(TlsOptions {
-            options: TlsData::NativeTls(self.mode, Arc::new(builder))
+            options: TlsData::NativeTls(Arc::new(builder))
         })
+    }
+
+    /// Builds client TLS options directly from a native-tls TlsConnectorBuilder instance
+    ///
+    /// This factory is useful when you need TLS properties that TlsOptionsBuilder does not support.
+    pub fn build_native_tls_from_tls_connector_builder(builder: native_tls::TlsConnectorBuilder) -> TlsOptions {
+        TlsOptions {
+            options: TlsData::NativeTls(Arc::new(builder))
+        }
     }
 }

--- a/gneiss-mqtt/src/features/gneiss_rustls.rs
+++ b/gneiss-mqtt/src/features/gneiss_rustls.rs
@@ -46,8 +46,17 @@ impl TlsOptionsBuilder {
         config.enable_sni = self.verify_peer;
 
         Ok(TlsOptions {
-            options: TlsData::Rustls(self.mode, Arc::new(config))
+            options: TlsData::Rustls(Arc::new(config))
         })
+    }
+
+    /// Builds client TLS options directly from a Rustls ClientConfig instance
+    ///
+    /// This factory is useful when you need TLS properties that TlsOptionsBuilder does not support.
+    pub fn build_rustls_from_client_config(config: rustls::ClientConfig) -> TlsOptions {
+        TlsOptions {
+            options: TlsData::Rustls(Arc::new(config))
+        }
     }
 }
 

--- a/gneiss-mqtt/src/features/gneiss_tokio/mod.rs
+++ b/gneiss-mqtt/src/features/gneiss_tokio/mod.rs
@@ -896,7 +896,7 @@ async fn wrap_stream_with_tls_rustls<S>(stream : Pin<Box<impl Future<Output=Mqtt
 
     let connector =
         match tls_options.options {
-            TlsData::Rustls(_, config) => { tokio_rustls::TlsConnector::from(config.clone()) }
+            TlsData::Rustls(config) => { tokio_rustls::TlsConnector::from(config.clone()) }
             _ => { panic!("Rustls stream wrapper invoked without Rustls configuration"); }
         };
 
@@ -913,7 +913,7 @@ async fn wrap_stream_with_tls_native_tls<S>(stream : Pin<Box<impl Future<Output=
 
     let connector =
         match tls_options.options {
-            TlsData::NativeTls(_, ntls_builder) => {
+            TlsData::NativeTls(ntls_builder) => {
                 let cx = ntls_builder.build()?;
                 tokio_native_tls::TlsConnector::from(cx)
             }


### PR DESCRIPTION
* Removes unnecessary mode field in tls data enum
* Adds static TlsOptions constructors that take Rustls and Native-tls configurations directly.  This enables the use of TLS configurations that are not naturally supported by the more limited TlsOptionsBuilder.