### PR TITLE
Interrupt retries

### DIFF
--- a/gneiss-mqtt/src/client/mod.rs
+++ b/gneiss-mqtt/src/client/mod.rs
@@ -600,6 +600,7 @@ impl MqttClientImpl {
             outbound_alias_resolver: client_config.outbound_alias_resolver_factory.map(|f| { f() }),
             protocol_mode: client_config.protocol_mode,
             post_reconnect_queue_drain_policy: client_config.post_reconnect_queue_drain_policy.unwrap_or_default(),
+            max_interrupted_retries: client_config.max_interrupted_retries,
         };
 
         let mut client_impl = MqttClientImpl {

--- a/gneiss-mqtt/src/error.rs
+++ b/gneiss-mqtt/src/error.rs
@@ -364,8 +364,8 @@ impl GneissError {
     }
 
     pub(crate) fn new_max_interrupted_retries_exceeded_error(source: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
-        GneissError::OtherError (
-            OtherErrorContext {
+        GneissError::MaxInterruptedRetriesExceeded (
+            MaxInterruptedRetriesExceededContext {
                 source : source.into()
             }
         )

--- a/gneiss-mqtt/src/testing/protocol.rs
+++ b/gneiss-mqtt/src/testing/protocol.rs
@@ -45,6 +45,7 @@ fn build_standard_test_config(protocol_version : i32) -> ProtocolStateConfig {
         outbound_alias_resolver: None,
         protocol_mode,
         post_reconnect_queue_drain_policy: PostReconnectQueueDrainPolicy::None,
+        max_interrupted_retries: None,
     }
 }
 


### PR DESCRIPTION
* Adds a client setting to control the maximum number of times a user-submitted operation will be retried when interrupted by a disconnection in a pending state.