### PR TITLE
Apply 311-oriented defaults to AWS IoT Core clients

### DIFF
--- a/gneiss-mqtt-aws/CHANGELOG.md
+++ b/gneiss-mqtt-aws/CHANGELOG.md
@@ -20,3 +20,6 @@ This document is currently hand-written and non-authoritative.
 
 ## 0.4.0
 * Threaded client support for mtls and custom auth
+
+## 0.5.0
+* When using MQTT311, apply some default settings designed to make the connection more reliable in the face of limit violations when using IoT Core

--- a/gneiss-mqtt/CHANGELOG.md
+++ b/gneiss-mqtt/CHANGELOG.md
@@ -57,3 +57,4 @@ This document is currently hand-written and non-authoritative.
 * MQTT 311 Support
 * Add support for a "slow start" mode after reconnection.  While in slow start, the client only processes one ackable packet at a time until all interrupted packets have been processed.  This setting is intended primarily for MQTT311 and AWS IoT Core.
 * Additional protocol error detection in the case of an ack mismatching the source operation type
+* Add support for limiting the number of times a user-submitted operation can be interrupted (waiting for ack) before getting failed

--- a/gneiss-mqtt/src/client/config.rs
+++ b/gneiss-mqtt/src/client/config.rs
@@ -935,6 +935,21 @@ impl MqttClientOptions {
     pub fn to_builder(self) -> MqttClientOptionsBuilder {
         MqttClientOptionsBuilder::new_from_options(self)
     }
+
+    #[doc(hidden)]
+    pub fn protocol_mode(&self) -> ProtocolMode {
+        self.protocol_mode
+    }
+
+    #[doc(hidden)]
+    pub fn post_reconnect_queue_drain_policy(&self) -> Option<PostReconnectQueueDrainPolicy> {
+        self.post_reconnect_queue_drain_policy
+    }
+
+    #[doc(hidden)]
+    pub fn max_interrupted_retries(&self) -> Option<u32> {
+        self.max_interrupted_retries
+    }
 }
 
 impl Debug for MqttClientOptions {


### PR DESCRIPTION
* AWS client builders now apply some special configuration settings to 311 clients to make the client more reliable in the face of limit violations that cause disconnections